### PR TITLE
Update Core.php

### DIFF
--- a/lib/Phile/Core.php
+++ b/lib/Phile/Core.php
@@ -135,6 +135,12 @@ class Core {
 		global $config;
 		@include_once(ROOT_DIR . 'config.php');
 
+		if (ini_get('date.timezone')) { // use system time only IF avaliable
+			$time = ini_get('date.timezone');
+		}
+		else {
+			$time = 'UTC'; // UTC by default
+		}
 		$defaults = array(
 			'site_title' => 'Phile',
 			'base_url' => \Phile\Utility::getBaseUrl(),
@@ -144,7 +150,7 @@ class Core {
 			'pages_order_by' => 'alpha',
 			'pages_order' => 'asc',
 			'excerpt_length' => 50,
-			'timezone' => date_default_timezone_get() // use system time if avaliable
+			'timezone' => $time
 			);
 
 		if(is_array($config)) {


### PR DESCRIPTION
Suppress the 

> Warning: phpinfo() [function.phpinfo]: It is not safe to rely on the system's timezone settings. You are _required_ to use the date.timezone setting or the date_default_timezone_set() function.

It depends of the php version and the server's settings.
