### PR TITLE
[FEATURE] change code of meta parser to use a service

### DIFF
--- a/default_config.php
+++ b/default_config.php
@@ -18,11 +18,12 @@ $config['timezone'] = $timezone; // The default timezone
 // also notice, each plugin has its own config namespace.
 // activate plugins
 $config['plugins'] = array(
-	'phileDemoPlugin' => array('active' => true),
-	'phileParserMarkdown' => array('active' => true), // the default parser
-	'phileTemplateTwig' => array('active' => true), // the default template engine
-	'philePhpFastCache' => array('active' => true), // the default cache engine
-	'phileSimpleFileDataPersistence' => array('active' => true), // the default data storage engine
+    'phileDemoPlugin' => array('active' => true),
+    'phileParserMarkdown' => array('active' => true), // the default parser
+    'phileParserMeta' => array('active' => true), // the default parser
+    'phileTemplateTwig' => array('active' => true), // the default template engine
+    'philePhpFastCache' => array('active' => true), // the default cache engine
+    'phileSimpleFileDataPersistence' => array('active' => true), // the default data storage engine
 );
 
 return $config;

--- a/lib/Phile/Parser/Meta.php
+++ b/lib/Phile/Parser/Meta.php
@@ -1,0 +1,40 @@
+<?php
+namespace Phile\Parser;
+
+class Meta implements MetaInterface {
+	/** @var array $config the configuration for this parser */
+	private $config;
+
+	/**
+	 * @param array $config
+	 */
+	public function __construct(array $config = null) {
+		if (!is_null($config)) {
+			$this->config = $config;
+		}
+	}
+
+	/**
+	 * @param $rawData
+	 *
+	 * @return array with key/value store
+	 */
+	public function parse($rawData) {
+		$rawData = trim($rawData);
+		$START   = (substr($rawData, 0, 2) == '/*') ? '/*' : '<!--';
+		$END     = (substr($rawData, 0, 2) == '/*') ? '*/' : '-->';
+
+		$metaPart = trim(substr($rawData, strlen($START), strpos($rawData, $END) - (strlen($END) + 1)));
+		// split by new lines
+		$headers = explode("\n", $metaPart);
+		$result  = array();
+		foreach ($headers as $line) {
+			$parts        = explode(':', $line, 2);
+			$key          = strtolower(array_shift($parts));
+			$val          = implode($parts);
+			$result[$key] = trim($val);
+		}
+
+		return $result;
+	}
+}

--- a/lib/Phile/Parser/MetaInterface.php
+++ b/lib/Phile/Parser/MetaInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Phile\Parser;
+
+interface MetaInterface {
+	/**
+	 * @param $rawData
+	 *
+	 * @return array with key/value store
+	 */
+	public function parse($rawData);
+}

--- a/lib/Phile/ServiceLocator.php
+++ b/lib/Phile/ServiceLocator.php
@@ -13,18 +13,24 @@ class ServiceLocator {
 	 */
 	protected static $services;
 
+	/**
+	 * @var array $serviceMap for mapping speaking names/keys to the interfaces
+	 */
 	protected static $serviceMap = array(
 		'Phile_Cache'               => 'Phile\Cache\CacheInterface',
 		'Phile_Template'            => 'Phile\Template\TemplateInterface',
 		'Phile_Parser'              => 'Phile\Parser\ParserInterface',
-		'Phile_Data_Persistence'    => 'Phile\Persistence\PersistenceInterface'
+		'Phile_Data_Persistence'    => 'Phile\Persistence\PersistenceInterface',
+        'Phile_Parser_Meta'         => 'Phile\Parser\MetaInterface',
 	);
 
 	/**
 	 * @param string $serviceKey the key for the service
 	 * @param mixed $object
-	 */
-	public static function registerService($serviceKey, $object) {
+     *
+     * @throws Exception
+     */
+    public static function registerService($serviceKey, $object) {
 		$interfaces = class_implements($object);
 		$interface = self::$serviceMap[$serviceKey];
 		if ($interfaces === FALSE || !in_array($interface, $interfaces)) {

--- a/plugins/phileParserMeta/config.php
+++ b/plugins/phileParserMeta/config.php
@@ -1,0 +1,4 @@
+<?php
+
+return array(
+);

--- a/plugins/phileParserMeta/plugin.php
+++ b/plugins/phileParserMeta/plugin.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Default Phile parser plugin for Markdown
+ */
+class PhileParserMeta extends \Phile\Plugin\AbstractPlugin implements \Phile\EventObserverInterface {
+	public function __construct() {
+		\Phile\Event::registerEvent('plugins_loaded', $this);
+	}
+
+	public function on($eventKey, $data = null) {
+		// check $eventKey for which you have registered
+		if ($eventKey == 'plugins_loaded') {
+			\Phile\ServiceLocator::registerService('Phile_Parser_Meta', new \Phile\Parser\Meta($this->settings));
+		}
+	}
+}


### PR DESCRIPTION
- added ServiceLocater service for meta parser
- remove old parser code and receive parser from ServiceLocator
- added new default plugin phileParserMeta with old parser code

Resolves: #76
Releases: 0.9.3
Related: #42
