### PR TITLE
fix issue with using spaces in meta

### DIFF
--- a/lib/Phile/Parser/Meta.php
+++ b/lib/Phile/Parser/Meta.php
@@ -32,7 +32,7 @@ class Meta implements MetaInterface {
 		$result  = array();
 		foreach ($headers as $line) {
 			$parts        = explode(':', $line, 2);
-			$key          = strtolower(array_shift($parts));
+			$key          = str_replace(' ', '_', strtolower(array_shift($parts)));
 			$val          = implode($parts);
 			$result[$key] = trim($val);
 		}


### PR DESCRIPTION
Now they are converted to underscores.

So "Area Title:" would become `{{ current_page.meta.area_title }}`
