### PR TITLE
replace special chars in meta with underscores

### DIFF
--- a/plugins/phile/parserMeta/Classes/Parser/Meta.php
+++ b/plugins/phile/parserMeta/Classes/Parser/Meta.php
@@ -47,7 +47,7 @@ class Meta implements MetaInterface {
 		$result  = array();
 		foreach ($headers as $line) {
 			$parts        = explode(':', $line, 2);
-			$key          = strtolower(array_shift($parts));
+			$key          = preg_replace('/[^\w+]/', '_', strtolower(array_shift($parts))); // replace all special characters with underscores
 			$val          = implode($parts);
 			$result[$key] = trim($val);
 		}


### PR DESCRIPTION
I made this change in the 0.9.3 version but it must have gotten lost in the transition. 

This code is better. It replaces any non-word or number characters with underscores. This makes the meta safe for the different template engines.
