### PR TITLE
Bugfix/next prev page

### DIFF
--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -219,6 +219,9 @@ class Page {
 			$pageRepository = new \Phile\Repository\Page();
 			$settings = Registry::get('Phile_Settings');
 			$allPages = $pageRepository->findAll($settings);
+			// for some reason using the same code as above returns false
+			// so I have to use this array keys hack
+			// not great, but it seems to work
 			$place = array_search('_'.$this->getMeta()->get('title'), array_keys($allPages));
 			$this->nextPage = $allPages[array_keys($allPages)[$place + 1]];
 		}


### PR DESCRIPTION
OK. So this was a pain. I managed to get a working version down. This is quite hacky.

Here is the pseudo-code version.
- get all the pages as an array (while obeying the meta sorting order)
- find the current pages index in the pages array
- return pages at the current pages index but +/- 1

I will need @NeoBlack to check this over incase I am being dumb.
