### PR TITLE
Update Core.php

### DIFF
--- a/lib/Phile/Core.php
+++ b/lib/Phile/Core.php
@@ -204,7 +204,7 @@ class Core {
 		 * @triggerEvent before_render_template this event is triggered before the template is rendered
 		 * @param \Phile\ServiceLocator\TemplateInterface the template engine
 		 */
-		Event::triggerEvent('before_render_template', array('templateEngine' => &$templateEngine));
+		Event::triggerEvent('before_render_template', array('templateEngine' => &$templateEngine,'page'=> &$this->page));
 
 		$templateEngine->setCurrentPage($this->page);
 		$output = $templateEngine->render();


### PR DESCRIPTION
Passing a reference to $this->page allows plugins triggered by the `before_render_template` event to actually modify the content of the page.  Useful if a plugin is introducing new functionality that is parsed by content in the plugin.
