### PR TITLE
ignore md files with a leading dot '.' as filename

### DIFF
--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -85,7 +85,8 @@ class Page {
 		if ($this->settings !== null) {
 			$options += $this->settings;
 		}
-		$files = Utility::getFiles($folder, '/^.*\\' . CONTENT_EXT . '/');
+		// ignore files with a leading '.' in its filename
+		$files = Utility::getFiles($folder, '/^.[^\.]*\\' . CONTENT_EXT . '/');
 		$pages = array();
 		foreach ($files as $file) {
 			if (str_replace($folder, '', $file) == '404' . CONTENT_EXT) {


### PR DESCRIPTION
As mentioned on issue #56, you would got a WSOD when you have a markdown file left open in your editor. It appeared it was because Phile also records files that were prepended with dot in its filename. 

For example, you have two files `index.md` and `.index.md` (VIm creates a backup with the same filename prepending with a dot and adds a `.swp` extension in most cases), however either Phile gets confused about the content for `/index` (does it load the `index.md` or `.index.md`?) or either it's because the URL of the latter one is invalid (I've never seen `/.index` URL before)

Anyway, this PR solves #56 by only recording filenames that are _not_ prepended with a dot `.` character.
