### PR TITLE
load settings if not loaded

### DIFF
--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -37,9 +37,8 @@ class Page {
 	 * the constructor
 	 */
 	public function __construct($settings = null) {
-		if ($settings === null) {
-			$this->settings = \Phile\Registry::get('Phile_Settings');
-		}
+		$this->settings = ($settings === null) ? \Phile\Registry::get('Phile_Settings') : $settings;
+
 		if (ServiceLocator::hasService('Phile_Cache')) {
 			$this->cache = ServiceLocator::getService('Phile_Cache');
 		}


### PR DESCRIPTION
Not sure if it's a bug or a feature, but the sorting didn't work because `$this->settings` was always empty, so I forced it to load the settings (if it's not already loaded) so the `$config['pages_order']` can be retrieved.
