### PR TITLE
[TASK] Change PHP minimum version to PHP 5.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Here is a small list of differences in design from typical flat-file CMSs:
 
 ##### Requirements
 
-* PHP `>=5.3`
+* PHP `>=5.4.0`
 * Apache with `mod_rewrite` enabled
 * [Composer](https://getcomposer.org/) (unless you use `git` and `zip` files for everything)
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "vendor-dir": "lib/vendor"
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "twig/twig": "1.15.*",
         "michelf/php-markdown": ">=1.4",
         "phile-cms/plugin-installer-plugin": "dev-master"


### PR DESCRIPTION
because PHP 5.3 reached end of life and because there some problems with special PHP 5.3 versions, we upgrade the minimum to PHP 5.4.0

Resolves: #122
Releases: 1.2.1
Related: #122
