### PR TITLE
[BUGFIX] Declare array before using it

### DIFF
--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -148,6 +148,7 @@ class Page {
 	 */
 	public function getPageOffset(\Phile\Model\Page $page, $offset = 0) {
 		$pages = $this->findAll();
+		$order = array();
 		foreach ($pages as $p) {
 			$order[] = $p->getFilePath();
 		}


### PR DESCRIPTION
You forgot to declare the array before actually using it. PHP5.4 complains about this, PHP5.5 does not.
