### PR TITLE
[BUGFIX] load `sub/index.md` if `sub.md` not found

### DIFF
--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -56,22 +56,16 @@ class Page {
 	 */
 	public function findByPath($path, $folder = CONTENT_DIR) {
 		$path = str_replace(Utility::getInstallPath(), '', $path);
-		$file = null;
 		$fullPath =  str_replace(array("\\", "//", "\\/", "/\\"), DIRECTORY_SEPARATOR, $folder.$path);
-		if (file_exists($fullPath . CONTENT_EXT)) {
-			$file = $fullPath . CONTENT_EXT;
-		}
-		if ($file == null) {
-			if (file_exists($fullPath . 'index' . CONTENT_EXT)) {
-				$file = $fullPath . 'index' . CONTENT_EXT;
-			}
+
+		$file = $fullPath . CONTENT_EXT;
+
+		// append '/index' to full path if file not found
+		if (!file_exists($file)) {
+			$file = $fullPath . '/index' . CONTENT_EXT;
 		}
 
-		if ($file !== null) {
-			return $this->getPage($file, $folder);
-		}
-
-		return null;
+		return (file_exists($file)) ? $this->getPage($file, $folder) : null;
 	}
 
 	/**


### PR DESCRIPTION
According to the documentation, when going to url `/sub` the core looks first for `content/sub.md` and then for `content/sub/index.md` if the first one doesn't exist. That didn't work before, but that's now fixed.

There was actually a leading slash `/` missing when appending `index` to the path name.

Resolves: #126
Documentation: #126
Releases: 1.3.0
Related: #126, #117, #119
