### PR TITLE
[BUGFIX] Use RecursiveRegexIterator with recursive regex

### DIFF
--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -79,8 +79,7 @@ class Page {
 	 */
 	public function findAll(array $options = array(), $folder = CONTENT_DIR) {
 		$options += $this->settings;
-		// ignore files with a leading '.' in its filename
-		$files = Utility::getFiles($folder, '/^.[^\.]*\\' . CONTENT_EXT . '/');
+		$files = Utility::getFiles($folder, '/^.*\\' . CONTENT_EXT . '$/i');
 		$pages = array();
 		foreach ($files as $file) {
 			if (str_replace($folder, '', $file) == '404' . CONTENT_EXT) {


### PR DESCRIPTION
Bugfix for those using PHP5.4, where the `pages` variable is always an empty
array. This is because you have to use a recursive iterator when recursively
iterating through the directories/files.

In addition, the regex must also have a trailing `i`, indicating that it will
be used recursively.

Also see [this user note](http://php.net/manual/en/class.recursivedirectoryiterator.php#97228).

**Releases:** 1.3.0
