### PR TITLE
[FEATURE] Drop '/index' from generated URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -23,12 +23,6 @@
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-l
-    RewriteCond %{REQUEST_URI} (.*)$
-    RewriteRule ^(.+)/$ http://%{HTTP_HOST}/$1 [R=301,L]
-
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteCond %{REQUEST_FILENAME} !-l
     RewriteRule .* index.php [L]
 </IfModule>
 

--- a/index.php
+++ b/index.php
@@ -12,8 +12,8 @@ require_once __DIR__ . '/lib/Phile/Bootstrap.php';
 ob_start();
 
 try {
-	$boostrap = \Phile\Bootstrap::getInstance()->initializeBasics();
-	$phileCore = new \Phile\Core($boostrap);
+	$bootstrap = \Phile\Bootstrap::getInstance()->initializeBasics();
+	$phileCore = new \Phile\Core($bootstrap);
 	echo $phileCore->render();
 } catch (\Phile\Exception $e) {
 	if (\Phile\ServiceLocator::hasService('Phile_ErrorHandler')) {

--- a/lib/Phile/Core.php
+++ b/lib/Phile/Core.php
@@ -86,6 +86,15 @@ class Core {
 		$uri = (strpos($_SERVER['REQUEST_URI'], '?') !== false) ? substr($_SERVER['REQUEST_URI'], 0, strpos($_SERVER['REQUEST_URI'], '?')) : $_SERVER['REQUEST_URI'];
 		$uri = str_replace('/' . \Phile\Utility::getInstallPath() . '/', '', $uri);
 		$uri = (strpos($uri, '/') === 0) ? substr($uri, 1) : $uri;
+
+		// strip '/index' if it exists (as per https://github.com/PhileCMS/Phile/pull/170)
+		if ($uri=="index" || preg_match("#/index$#", $uri)>0) {
+			// we can't just check if 'index' are the last 5 letters, because then URLs
+			// like 'example.com/blog/global-economic-index' would also be stripped...
+			$uri = rtrim(Utility::getBaseUrl() . '/' . substr($uri, 0, -5), '/');
+			Utility::redirect($uri, 301);
+		}
+
 		/**
 		 * @triggerEvent request_uri this event is triggered after the request uri is detected.
 		 *

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -57,12 +57,18 @@ class Page {
 	protected $nextPage;
 
 	/**
+	 * @var string The content folder, as passed to the class constructor when initiating the object.
+	 */
+	protected $contentFolder = CONTENT_DIR;
+
+	/**
 	 * the constructor
 	 *
 	 * @param        $filePath
 	 * @param string $folder
 	 */
 	public function __construct($filePath, $folder = CONTENT_DIR) {
+		$this->contentFolder = $folder;
 		$this->setFilePath($filePath);
 
 		/**
@@ -160,14 +166,13 @@ class Page {
 	}
 
 	/**
-	 * Generate a pretty URL for the provided filename (and folder)
+	 * Generate a pretty URL for the provided filename
 	 *
 	 * @param string $filePath
-	 * @param string $folder
 	 * @return string
 	 */
-	protected function buildUrl($filePath, $folder = CONTENT_DIR) {
-		$url = str_replace($folder, '', $filePath);
+	protected function buildUrl($filePath) {
+		$url = str_replace($this->contentFolder, '', $filePath);
 		$url = str_replace(CONTENT_EXT, '', $url);
 		$url = str_replace(DIRECTORY_SEPARATOR, '/', $url);
 

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -171,7 +171,14 @@ class Page {
 		$url = str_replace($folder, '', $filePath);
 		$url = str_replace(CONTENT_EXT, '', $url);
 		$url = str_replace(DIRECTORY_SEPARATOR, '/', $url);
-		$url = preg_replace('#(.*)/?index$#', '$1', $url);
+
+		// strip '/index' from the URL (can't just check if last 5 letters are 'index',
+		// because then URL's like "example.com/blog/global-economic-index" would also
+		// be chopped...)
+		$url = preg_replace('#(.*)/index$#', '$1', $url);
+
+		// if the whole url is 'index', then drop that as well
+		$url = preg_replace('#^index$#', '', $url);
 		$url = ltrim($url, '/');
 
 		return $url;

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -87,8 +87,8 @@ class Page {
 		$this->url = str_replace($folder, '', $this->filePath);
 		$this->url = str_replace(CONTENT_EXT, '', $this->url);
 		$this->url = str_replace(DIRECTORY_SEPARATOR, '/', $this->url);
-		$this->url = preg_replace('#(.*)/index$#', '$1', $this->url);
-		$this->url = trim($this->url, '/');
+		$this->url = preg_replace('#(.*)/?index$#', '$1', $this->url);
+		$this->url = ltrim($this->url, '/');
 
 		$this->parser = ServiceLocator::getService('Phile_Parser');
 	}

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -68,8 +68,8 @@ class Page {
 		/**
 		 * @triggerEvent before_load_content this event is triggered before the content is loaded
 		 *
-		 * @param                   string filePath the path to the file
-		 * @param \Phile\Model\Page page   the page model
+		 * @param            string filePath the path to the file
+		 * @param \Phile\Model\Page page     the page model
 		 */
 		Event::triggerEvent('before_load_content', array('filePath' => &$this->filePath, 'page' => &$this));
 		if (file_exists($this->filePath)) {
@@ -79,9 +79,9 @@ class Page {
 		/**
 		 * @triggerEvent after_load_content this event is triggered after the content is loaded
 		 *
-		 * @param                   string filePath the path to the file
-		 * @param                   string rawData the raw data
-		 * @param \Phile\Model\Page page   the page model
+		 * @param            string filePath the path to the file
+		 * @param            string rawData  the raw data
+		 * @param \Phile\Model\Page page     the page model
 		 */
 		Event::triggerEvent('after_load_content', array('filePath' => &$this->filePath, 'rawData' => $this->rawData, 'page' => &$this));
 		$this->url = str_replace($folder, '', $this->filePath);
@@ -102,16 +102,16 @@ class Page {
 		/**
 		 * @triggerEvent before_parse_content this event is triggered before the content is parsed
 		 *
-		 * @param                   string content the raw data
-		 * @param \Phile\Model\Page page   the page model
+		 * @param            string content the raw data
+		 * @param \Phile\Model\Page page    the page model
 		 */
 		Event::triggerEvent('before_parse_content', array('content' => $this->content, 'page' => &$this));
 		$content = $this->parser->parse($this->content);
 		/**
 		 * @triggerEvent after_parse_content this event is triggered after the content is parsed
 		 *
-		 * @param                   string content the parsed content
-		 * @param \Phile\Model\Page page   the page model
+		 * @param            string content the parsed content
+		 * @param \Phile\Model\Page page    the page model
 		 */
 		Event::triggerEvent('after_parse_content', array('content' => &$content, 'page' => &$this));
 

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -63,7 +63,7 @@ class Page {
 	 * @param string $folder
 	 */
 	public function __construct($filePath, $folder = CONTENT_DIR) {
-		$this->filePath = $filePath;
+		$this->setFilePath($filePath);
 
 		/**
 		 * @triggerEvent before_load_content this event is triggered before the content is loaded
@@ -84,11 +84,7 @@ class Page {
 		 * @param \Phile\Model\Page page     the page model
 		 */
 		Event::triggerEvent('after_load_content', array('filePath' => &$this->filePath, 'rawData' => $this->rawData, 'page' => &$this));
-		$this->url = str_replace($folder, '', $this->filePath);
-		$this->url = str_replace(CONTENT_EXT, '', $this->url);
-		$this->url = str_replace(DIRECTORY_SEPARATOR, '/', $this->url);
-		$this->url = preg_replace('#(.*)/?index$#', '$1', $this->url);
-		$this->url = ltrim($this->url, '/');
+		$this->url = $this->buildUrl($this->filePath, $folder);
 
 		$this->parser = ServiceLocator::getService('Phile_Parser');
 	}
@@ -162,6 +158,23 @@ class Page {
 	 */
 	public function getTitle() {
 		return $this->getMeta()->get('title');
+	}
+
+	/**
+	 * Generate a pretty URL for the provided filename (and folder)
+	 *
+	 * @param string $filePath
+	 * @param string $folder
+	 * @return string
+	 */
+	public function buildUrl($filePath, $folder = CONTENT_DIR) {
+		$url = str_replace($folder, '', $filePath);
+		$url = str_replace(CONTENT_EXT, '', $url);
+		$url = str_replace(DIRECTORY_SEPARATOR, '/', $url);
+		$url = preg_replace('#(.*)/?index$#', '$1', $url);
+		$url = ltrim($url, '/');
+
+		return $url;
 	}
 
 	/**

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -84,7 +84,6 @@ class Page {
 		 * @param \Phile\Model\Page page     the page model
 		 */
 		Event::triggerEvent('after_load_content', array('filePath' => &$this->filePath, 'rawData' => $this->rawData, 'page' => &$this));
-		$this->url = $this->buildUrl($this->filePath, $folder);
 
 		$this->parser = ServiceLocator::getService('Phile_Parser');
 	}
@@ -167,7 +166,7 @@ class Page {
 	 * @param string $folder
 	 * @return string
 	 */
-	public function buildUrl($filePath, $folder = CONTENT_DIR) {
+	protected function buildUrl($filePath, $folder = CONTENT_DIR) {
 		$url = str_replace($folder, '', $filePath);
 		$url = str_replace(CONTENT_EXT, '', $url);
 		$url = str_replace(DIRECTORY_SEPARATOR, '/', $url);
@@ -200,6 +199,7 @@ class Page {
 	 */
 	public function setFilePath($filePath) {
 		$this->filePath = $filePath;
+		$this->url = $this->buildUrl($this->filePath);
 	}
 
 	/**

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -87,9 +87,8 @@ class Page {
 		$this->url = str_replace($folder, '', $this->filePath);
 		$this->url = str_replace(CONTENT_EXT, '', $this->url);
 		$this->url = str_replace(DIRECTORY_SEPARATOR, '/', $this->url);
-		if (strpos($this->url, '/') === 0) {
-			$this->url = substr($this->url, 1);
-		}
+		$this->url = preg_replace('#(.*)/index$#', '$1', $this->url);
+		$this->url = trim($this->url, '/');
 
 		$this->parser = ServiceLocator::getService('Phile_Parser');
 	}

--- a/tests/Phile/Model/PageTest.php
+++ b/tests/Phile/Model/PageTest.php
@@ -49,7 +49,35 @@ class PageTest extends \PHPUnit_Framework_TestCase {
 	 *
 	 */
 	public function testPageHasUrl() {
-		$this->assertGreaterThan(0, strlen($this->pageRepository->findByPath('/')->getUrl()));
+		// root index
+		$this->assertEquals(
+			'',
+			$this->pageRepository->findByPath('/')->getUrl()
+		);
+
+		// check if '/index' is stripped correctly
+		$this->assertEquals(
+			'',
+			$this->pageRepository->findByPath('/index')->getUrl()
+		);
+
+		// root page
+		$this->assertEquals(
+			'setup',
+			$this->pageRepository->findByPath('/setup')->getUrl()
+		);
+
+		// sub index
+		$this->assertEquals(
+			'sub',
+			$this->pageRepository->findByPath('/sub/index')->getUrl()
+		);
+
+		// sub page
+		$this->assertEquals(
+			'sub/page',
+			$this->pageRepository->findByPath('/sub/page')->getUrl()
+		);
 	}
 
 	/**


### PR DESCRIPTION
The default URLs that are generated for a page include '/index' at the end if the underlying file is called 'index.md'. In my opinion, this is unnecessary and ugly. I'd rather have a link called '/projects' than a link called '/projects/index'. Both would result in the same page anyway, so it's safe to drop them here for cosmetic reasons.