### PR TITLE
fixes hard coded slash as directory separator and some refactoring

### DIFF
--- a/lib/Phile/Core.php
+++ b/lib/Phile/Core.php
@@ -88,7 +88,7 @@ class Core {
 			$uri = substr($uri, 0, strpos($uri, '?'));
 		}
 		$uri = str_replace('/' . Utility::getInstallPath() . '/', '', $uri);
-		$uri = rtrim($uri, '/');
+		$uri = ltrim($uri, '/');
 
 		/**
 		 * @triggerEvent request_uri this event is triggered after the request uri is detected.

--- a/lib/Phile/Core.php
+++ b/lib/Phile/Core.php
@@ -83,15 +83,19 @@ class Core {
 	 * initialize the current page
 	 */
 	protected function initializeCurrentPage() {
-		$uri = (strpos($_SERVER['REQUEST_URI'], '?') !== false) ? substr($_SERVER['REQUEST_URI'], 0, strpos($_SERVER['REQUEST_URI'], '?')) : $_SERVER['REQUEST_URI'];
-		$uri = str_replace('/' . \Phile\Utility::getInstallPath() . '/', '', $uri);
-		$uri = (strpos($uri, '/') === 0) ? substr($uri, 1) : $uri;
+		$uri = $_SERVER['REQUEST_URI'];
+		if (strpos($uri, '?') !== false) {
+			$uri = substr($uri, 0, strpos($uri, '?'));
+		}
+		$uri = str_replace('/' . Utility::getInstallPath() . '/', '', $uri);
+		$uri = rtrim($uri, '/');
+
 		/**
 		 * @triggerEvent request_uri this event is triggered after the request uri is detected.
 		 *
 		 * @param uri the uri
 		 */
-		Event::triggerEvent('request_uri', array('uri' => $uri));
+		Event::triggerEvent('request_uri', ['uri' => $uri]);
 
 		// use the current url to find the page
 		$page = $this->pageRepository->findByPath($uri);

--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -8,7 +8,6 @@ use Phile\Exception;
 use Phile\ServiceLocator;
 use Phile\Utility;
 
-
 /**
  * the Repository class for pages
  *
@@ -55,17 +54,26 @@ class Page {
 	 * @return null|\Phile\Model\Page
 	 */
 	public function findByPath($path, $folder = CONTENT_DIR) {
-		$path = str_replace(Utility::getInstallPath(), '', $path);
-		$fullPath =  str_replace(array("\\", "//", "\\/", "/\\"), DIRECTORY_SEPARATOR, $folder.$path);
+		$page = null;
+		$DS = DIRECTORY_SEPARATOR;
 
+		$path = str_replace(Utility::getInstallPath(), '', $path);
+		$fullPath = str_replace(["\\", "//", "\\/", "/\\"], $DS, $folder . $path);
+		$fullPath = rtrim($fullPath, $DS);
 		$file = $fullPath . CONTENT_EXT;
 
-		// append '/index' to full path if file not found
-		if (!file_exists($file)) {
-			$file = $fullPath . '/index' . CONTENT_EXT;
+		$exists = file_exists($file);
+		if (!$exists) {
+			// if file isn't found check if it's a sub and a sub/index exists
+			$file = $fullPath . $DS . 'index' . CONTENT_EXT;
+			$exists = file_exists($file);
 		}
 
-		return (file_exists($file)) ? $this->getPage($file, $folder) : null;
+		if ($exists) {
+			$page = $this->getPage($file, $folder);
+		}
+
+		return $page;
 	}
 
 	/**

--- a/tests/Phile/Repository/PageTest.php
+++ b/tests/Phile/Repository/PageTest.php
@@ -39,6 +39,22 @@ class PageTest extends \PHPUnit_Framework_TestCase {
 		$page = $this->pageRepository->findByPath('/');
 		$this->assertInstanceOf('\Phile\Model\Page', $page);
 		$this->assertEquals('Welcome', $page->getTitle());
+
+		$page = $this->pageRepository->findByPath('/sub');
+		$this->assertInstanceOf('\Phile\Model\Page', $page);
+		$this->assertStringEndsWith('sub/index.md', $page->getFilePath());
+
+		$page = $this->pageRepository->findByPath('/sub/page');
+		$this->assertInstanceOf('\Phile\Model\Page', $page);
+		$this->assertStringEndsWith('sub/page.md', $page->getFilePath());
+	}
+
+	/**
+	 *
+	 */
+	public function testPageCanNotBeFoundByPath() {
+		$page = $this->pageRepository->findByPath('/foo');
+		$this->assertNull($page);
 	}
 
 	/**


### PR DESCRIPTION
replaces a hardcoded slash in `Repository/Page::findByPath()` with a proper directory separator and some minor refactoring for better readability