### PR TITLE
[BUGFIX] Nginx: https/http protocol detection

### DIFF
--- a/lib/Phile/Core/Utility.php
+++ b/lib/Phile/Core/Utility.php
@@ -24,7 +24,7 @@ class Utility {
 			return '';
 		}
 		$protocol = 'http';
-		if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') {
+		if (isset($_SERVER['HTTPS']) && ( strtolower($_SERVER['HTTPS']) == 'on' || $_SERVER['HTTPS'] == '1' ) ) {
 			$protocol = 'https';
 		}
 

--- a/lib/Phile/Core/Utility.php
+++ b/lib/Phile/Core/Utility.php
@@ -24,7 +24,7 @@ class Utility {
 			return '';
 		}
 		$protocol = 'http';
-		if (isset($_SERVER['HTTPS']) && ( strtolower($_SERVER['HTTPS']) == 'on' || $_SERVER['HTTPS'] == '1' ) ) {
+		if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off' ) {
 			$protocol = 'https';
 		}
 


### PR DESCRIPTION
In Nginx the `$_SERVER['HTTPS']` is always set, but when it is not https, it will be empty.

In Wordpress they use the following function
```php
function is_ssl() {
    if ( isset($_SERVER['HTTPS']) ) {
        if ( 'on' == strtolower($_SERVER['HTTPS']) )
            return true;
        if ( '1' == $_SERVER['HTTPS'] )
            return true;
    } elseif ( isset($_SERVER['SERVER_PORT']) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
        return true;
    }
    return false;
}
```

Checking for the port is not very good, imho, but the first part of the function should be correct.
Instead of checking for the variable not to be `off`, you should check for it to be `on`.

I have tested it on Nginx with/without https. I have tested it on Apache without https, but haven't any https Apache hosts where I can check it.

So please do some little testing before merging it. I have fixed this for a client, running on my Nginx installation, but I'm not experienced with PhileCMS, so please test a bit more than I have doen :)