### PR TITLE
urldecode URIs before turning into filename

### DIFF
--- a/lib/Phile/Core.php
+++ b/lib/Phile/Core.php
@@ -86,6 +86,7 @@ class Core {
 		$uri = (strpos($_SERVER['REQUEST_URI'], '?') !== false) ? substr($_SERVER['REQUEST_URI'], 0, strpos($_SERVER['REQUEST_URI'], '?')) : $_SERVER['REQUEST_URI'];
 		$uri = str_replace('/' . \Phile\Utility::getInstallPath() . '/', '', $uri);
 		$uri = (strpos($uri, '/') === 0) ? substr($uri, 1) : $uri;
+		$uri = urldecode($uri);
 		/**
 		 * @triggerEvent request_uri this event is triggered after the request uri is detected.
 		 *


### PR DESCRIPTION
Any incoming URIs should be treated with urldecode() before they are converted to a file paths. Otherwise markdown files with spaces or accents in them will not work.