### PR TITLE
closes HTTP response header should specify charset #166

### DIFF
--- a/default_config.php
+++ b/default_config.php
@@ -10,6 +10,8 @@ $config['pages_order']    = 'meta.title:desc'; // Order pages by "title" (alpha)
 // figure out the timezone
 $config['timezone']       = (ini_get('date.timezone')) ? ini_get('date.timezone') : 'UTC'; // The default timezone
 
+$config['charset']    = 'utf-8'; // charset used for HTML & Markdown files
+
 // only extend $config['plugins'] and not overwrite it, because some core plugins
 // will be added to this config option by default. So, use this option in this way:
 // $config['plugins']['myCustomPlugin'] = array('active' => true);

--- a/lib/Phile/Core.php
+++ b/lib/Phile/Core.php
@@ -3,6 +3,7 @@
  * the core of Phile
  */
 namespace Phile;
+use Phile\Core\Response;
 use Phile\Exception\PluginException;
 
 /**
@@ -45,6 +46,11 @@ class Core {
 	protected $output;
 
 	/**
+	 * @var \Phile\Core\Response
+	 */
+	protected $response;
+
+	/**
 	 * The constructor carries out all the processing in Phile.
 	 * Does URL routing, Markdown processing and Twig processing.
 	 *
@@ -56,6 +62,7 @@ class Core {
 		$this->settings = \Phile\Registry::get('Phile_Settings');
 
 		$this->pageRepository = new \Phile\Repository\Page();
+		$this->response = (new Response)->setCharset($this->settings['charset']);
 
 		// Setup Check
 		$this->checkSetup();
@@ -76,7 +83,7 @@ class Core {
 	 * @return string
 	 */
 	public function render() {
-		return $this->output;
+		return $this->response->send();
 	}
 
 	/**
@@ -107,7 +114,7 @@ class Core {
 		if ($page instanceof \Phile\Model\Page) {
 			$this->page = $page;
 		} else {
-			header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
+			$this->response->setStatusCode(404);
 			$this->page = $this->pageRepository->findByPath('404');
 		}
 	}
@@ -198,6 +205,6 @@ class Core {
 		 * @param                                         string the generated ouput
 		 */
 		Event::triggerEvent('after_render_template', array('templateEngine' => &$templateEngine, 'output' => &$output));
-		$this->output = $output;
+		$this->response->setBody($output);
 	}
 }

--- a/lib/Phile/Core/Response.php
+++ b/lib/Phile/Core/Response.php
@@ -61,13 +61,13 @@
 
     public function send() {
       $this->setHeader('Content-Type', 'text/html; charset=' . $this->charset);
-      $this->_outputHeader();
+      $this->outputHeader();
       http_response_code($this->statusCode);
       echo $this->body;
     }
 
-    protected function _outputHeader(){
-      foreach($this->headers as $header) {
+    protected function outputHeader() {
+      foreach ($this->headers as $header) {
         header($header);
       }
     }

--- a/lib/Phile/Core/Response.php
+++ b/lib/Phile/Core/Response.php
@@ -54,11 +54,15 @@
 
     public function send() {
       $this->setHeader('Content-Type', 'text/html; charset=' . $this->charset);
+      $this->_outputHeader();
+      http_response_code($this->statusCode);
+      echo $this->body;
+    }
+
+    protected function _outputHeader(){
       foreach($this->headers as $header) {
         header($header);
       }
-      http_response_code($this->statusCode);
-      echo $this->body;
     }
 
   }

--- a/lib/Phile/Core/Response.php
+++ b/lib/Phile/Core/Response.php
@@ -42,8 +42,15 @@
       return $this;
     }
 
+    /**
+     * Set HTTP-header
+     *
+     * @param string $key
+     * @param string $value
+     * @return $this
+     */
     public function setHeader($key, $value) {
-      $this->headers[] = "$key: $value";
+      $this->headers[$key] = "$key: $value";
       return $this;
     }
 

--- a/lib/Phile/Core/Response.php
+++ b/lib/Phile/Core/Response.php
@@ -1,0 +1,65 @@
+<?php
+
+  namespace Phile\Core;
+
+  /**
+   * Response class implements HTTP response handling
+   *
+   * @author PhileCMS
+   * @link https://philecms.com
+   * @license http://opensource.org/licenses/MIT
+   * @package Phile
+   */
+  class Response {
+
+    /**
+     * @var string HTTP body
+     */
+    protected $body = '';
+
+    /**
+     * @var string charset
+     */
+    protected $charset = 'utf-8';
+
+    /**
+     * @var array HTTP-headers
+     */
+    protected $headers = [];
+
+    /**
+     * @var int HTTP status code
+     */
+    protected $statusCode = 200;
+
+    public function setBody($body) {
+      $this->body = $body;
+      return $this;
+    }
+
+    public function setCharset($charset) {
+      $this->charset = $charset;
+      return $this;
+    }
+
+    public function setHeader($key, $value) {
+      $this->headers[] = "$key: $value";
+      return $this;
+    }
+
+    public function setStatusCode($code) {
+      $this->statusCode = $code;
+      return $this;
+    }
+
+    public function send() {
+      $this->setHeader('Content-Type', 'text/html; charset=' . $this->charset);
+      foreach($this->headers as $header) {
+        header($header);
+      }
+      http_response_code($this->statusCode);
+      echo $this->body;
+    }
+
+  }
+

--- a/tests/Phile/Core/ResponseTest.php
+++ b/tests/Phile/Core/ResponseTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace PhileTest\Core;
+
+use Phile\Core\Response;
+
+/**
+* the ResponseTest class
+*
+* @author  PhileCms
+* @link    https://philecms.com
+* @license http://opensource.org/licenses/MIT
+* @package PhileTest
+*/
+class ResponseTest extends \PHPUnit_Framework_TestCase {
+
+  /**
+   * @var \Phile\Core\Response
+   */
+  protected $response;
+
+  protected function setUp() {
+    parent::setUp();
+    $this->response = $this->getMock('\Phile\Core\Response', ['setHeader']);
+  }
+
+  protected function tearDown() {
+    unset($this->response);
+  }
+
+  public function testDefaultCharset() {
+    $this->response->expects($this->once())
+      ->method('setHeader')
+      ->with('Content-Type', 'text/html; charset=utf-8');
+    $this->response->send();
+  }
+
+  public function testSetCharset() {
+    $this->response->expects($this->once())
+      ->method('setHeader')
+      ->with('Content-Type', 'text/html; charset=latin-1');
+    $this->response->setCharset('latin-1')->send();
+  }
+
+  public function testSetBody() {
+    $this->response->setBody('foo');
+    $this->response->send();
+    $this->expectOutputString('foo');
+  }
+
+}

--- a/tests/Phile/Core/ResponseTest.php
+++ b/tests/Phile/Core/ResponseTest.php
@@ -21,7 +21,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 
   protected function setUp() {
     parent::setUp();
-    $this->response = $this->getMock('\Phile\Core\Response', ['_outputHeader']);
+    $this->response = $this->getMock('\Phile\Core\Response', ['outputHeader']);
   }
 
   protected function tearDown() {

--- a/tests/Phile/Core/ResponseTest.php
+++ b/tests/Phile/Core/ResponseTest.php
@@ -21,7 +21,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 
   protected function setUp() {
     parent::setUp();
-    $this->response = $this->getMock('\Phile\Core\Response', ['setHeader']);
+    $this->response = $this->getMock('\Phile\Core\Response', ['_outputHeader']);
   }
 
   protected function tearDown() {
@@ -29,6 +29,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
   }
 
   public function testDefaultCharset() {
+    $this->response = $this->getMock('\Phile\Core\Response', ['setHeader']);
     $this->response->expects($this->once())
       ->method('setHeader')
       ->with('Content-Type', 'text/html; charset=utf-8');
@@ -36,6 +37,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
   }
 
   public function testSetCharset() {
+    $this->response = $this->getMock('\Phile\Core\Response', ['setHeader']);
     $this->response->expects($this->once())
       ->method('setHeader')
       ->with('Content-Type', 'text/html; charset=latin-1');
@@ -43,8 +45,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
   }
 
   public function testSetBody() {
-    $this->response->setBody('foo');
-    $this->response->send();
+    $this->response->setBody('foo')->send();
     $this->expectOutputString('foo');
   }
 

--- a/themes/default/index.html
+++ b/themes/default/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
 <head>
-	<meta charset="utf-8" />
+	<meta charset="{{ config.charset }}" />
 	<base href="{{ base_url }}/" />
 	<title>{% if meta.title %}{{ meta.title }} | {% endif %}{{ site_title }}</title>
 	{% if meta.description %}


### PR DESCRIPTION
- new $config['charset']
- charset meta-tag in default theme template is set to $config['charset']
- new lightweight Response class which handles HTTP charset, status-code and body