### PR TITLE
move PHPUnit config-params from CLI-arguments to XML config-file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 - |
   echo;
   echo "Running unit tests";
-  lib/vendor/bin/phpunit/phpunit
+  lib/vendor/bin/phpunit
 - |
   echo; echo "Running php lint"; /bin/bash -c "
     if ! find lib -name \*.php -not -path 'lib/vendor/*' -exec php -l {} \; > /tmp/errors 2>&1; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 - |
   echo;
   echo "Running unit tests";
-  lib/vendor/phpunit/phpunit/phpunit --bootstrap tests/phpunit_bootstrap.php --color tests/
+  lib/vendor/bin/phpunit/phpunit
 - |
   echo; echo "Running php lint"; /bin/bash -c "
     if ! find lib -name \*.php -not -path 'lib/vendor/*' -exec php -l {} \; > /tmp/errors 2>&1; then

--- a/build.xml
+++ b/build.xml
@@ -131,9 +131,9 @@
 
     <!-- ## tests ## -->
     <target name="tests">
-        <property name="tests.all" value="lib/vendor/phpunit/phpunit/phpunit --colors --bootstrap tests/phpunit_bootstrap.php tests/"/>
+        <property name="tests.all" value="lib/vendor/bin/phpunit"/>
+        <echo msg="Command run: '${tests.all}' (using phpunit.xml configuration file)"/>
         <echo msg="Running PHPUnit test cases…"/>
-        <echo msg="Command run: '${tests.all}'"/>
         <exec command="${tests.all}" logoutput="true" />
     </target>
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        bootstrap="tests/phpunit_bootstrap.php"
+        colors="true"
+        >
+    <testsuites>
+        <testsuite name="core">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
- allows to run the tests with the common `<vendor-dir>/bin/phpunit` call without arguments
- aggregates PHPUnit setting in one place (xml file) instead of many places (CLI arguments)