### PR TITLE
Make sure that $this->dataDirectory exists

### DIFF
--- a/plugins/phile/simpleFileDataPersistence/Classes/Persistence/SimpleFileDataPersistence.php
+++ b/plugins/phile/simpleFileDataPersistence/Classes/Persistence/SimpleFileDataPersistence.php
@@ -24,6 +24,9 @@ class SimpleFileDataPersistence implements PersistenceInterface {
 	 */
 	public function __construct() {
 		$this->dataDirectory = LIB_DIR . 'datastorage/';
+		if (!is_dir($this->dataDirectory)) {
+			mkdir($this->dataDirectory, 0755);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This directory exists in the default setup, but you can't guarantee that a user won't accidentally delete/empty it (as part of a grunt deployment task, for example). Therefore, we need to ensure that it exists BEFORE we try to create files in the directory.