### PR TITLE
Delete 'cache' and 'datastorage' directories from repository and only create them when required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Thumbs.db
 
 # distribution build directory
 dist/*
+
 # phpDocs
 docs/*
 
@@ -32,5 +33,7 @@ temp/cache/*
 !temp/cache/index.html
 
 # datastorage
-datastorage/*
-!datastorage/.htaccess
+lib/datastorage/*
+
+# cache
+lib/cache/*

--- a/lib/.htaccess
+++ b/lib/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all

--- a/lib/cache/.gitignore
+++ b/lib/cache/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/lib/datastorage/.htaccess
+++ b/lib/datastorage/.htaccess
@@ -1,5 +1,0 @@
-order deny, allow 
-
-deny from all 
-
-allow from 127.0.0.1

--- a/plugins/.htaccess
+++ b/plugins/.htaccess
@@ -1,0 +1,2 @@
+Order deny,allow
+Deny from all

--- a/plugins/phile/phpFastCache/Classes/Plugin.php
+++ b/plugins/phile/phpFastCache/Classes/Plugin.php
@@ -37,7 +37,25 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\Even
 				require_once(\Phile\Utility::resolveFilePath('MOD:phile/phpFastCache/lib/phpfastcache/phpfastcache.php'));
 
 				\phpFastCache::setup($this->settings);
-				$cache = phpFastCache();
+
+				try {
+					// try to instantiate a new cache
+					$cache = phpFastCache();
+				} catch (\Exception $e) {
+					if ($e->getCode()==100) {
+						// An exception with error code 100 means that the cache directory is not
+						// writable or does not exist. Usually this would mean that this is the
+						// first time that the cache is actually switched on. We try to create
+						// the cache directory with the proper access rights and try again.
+						if (!file_exists($this->settings['path'])) {
+							@mkdir($this->settings['path'], 0755);
+						}
+
+						// Try again. If there is still an error at this point, then show the
+						// exception (we don't catch it)
+						$cache = phpFastCache();
+					}
+				}
 				\Phile\ServiceLocator::registerService('Phile_Cache', new \Phile\Plugin\Phile\PhpFastCache\PhpFastCache($cache));
 			}
 		}


### PR DESCRIPTION
This addresses the issue mentioned in https://github.com/PhileCMS/Phile/pull/182: that creating a 'datastorage' directory on the fly does not recreate everything that was in there in the original repository – notably, a .htaccess file.

The way I've set it up now is to remove the 'cache' and 'datastorage' directories from the repository altogether, and to only create them when we need them.

I've addressed the security issue by preventing access to the whole 'lib/' directory, and to the whole 'plugins/' directory while we're at it. I don't think that there's anything in there that needs to be accessible from the outside (right?).