### PR TITLE
streamline and speed up travis-ci tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,12 @@ notifications:
 # Scripts
 before_script:
 - composer selfupdate --quiet
-- composer require 'phpunit/phpunit=4.2.*' --prefer-source
-- composer install -n --prefer-source --dev
+- composer install -n --prefer-source --no-dev
 script:
 - |
   echo;
   echo "Running unit tests";
-  lib/vendor/bin/phpunit
+  phpunit;
 - |
   echo; echo "Running php lint"; /bin/bash -c "
     if ! find lib -name \*.php -not -path 'lib/vendor/*' -exec php -l {} \; > /tmp/errors 2>&1; then


### PR DESCRIPTION
- don't install outdated phpunit 4.2
- don't install Phile's dev-requirements
- use travis-ci's phpunit

At the moment tests only require phpunit and installing the dev-requirements
is significantly slowing down the travis-ci test-runs.