### PR TITLE
refactor url handling

### DIFF
--- a/default_config.php
+++ b/default_config.php
@@ -1,7 +1,14 @@
 <?php
 
-// try to figure out the install path
-$config['base_url']       = \Phile\Utility::getBaseUrl(); // use the Utility class to guess the base_url
+/*
+ * Base URL to Phile installation without trailing slash
+ *
+ * e.g. `http://example.com` or `http://example.com/phile`
+ *
+ * Default: try to resolve automatically in Router
+ */
+$config['base_url']       = \Phile\Core\Router::getBaseUrl();
+
 $config['site_title']     = 'PhileCMS'; // Site title
 $config['theme']          = 'default'; // Set the theme
 $config['date_format']    = 'jS M Y'; // Set the PHP date format

--- a/index.php
+++ b/index.php
@@ -12,9 +12,10 @@ require_once __DIR__ . '/lib/Phile/Bootstrap.php';
 ob_start();
 
 try {
-	$bootstrap = \Phile\Bootstrap::getInstance()->initializeBasics();
-	$phileCore = new \Phile\Core($bootstrap);
-	echo $phileCore->render();
+	\Phile\Bootstrap::getInstance()->initializeBasics();
+	$response = new \Phile\Core\Response();
+	$phileCore = new \Phile\Core($response);
+	$phileCore->render();
 } catch (\Phile\Exception $e) {
 	if (\Phile\ServiceLocator::hasService('Phile_ErrorHandler')) {
 		ob_end_clean();

--- a/lib/Phile/Core.php
+++ b/lib/Phile/Core.php
@@ -3,7 +3,11 @@
  * the core of Phile
  */
 namespace Phile;
+use Phile\Core\Request;
 use Phile\Core\Response;
+use Phile\Core\Router;
+use Phile\Model\Page;
+use Phile\Utility;
 use Phile\Exception\PluginException;
 
 /**
@@ -15,11 +19,6 @@ use Phile\Exception\PluginException;
  * @package Phile
  */
 class Core {
-	/**
-	 * @var Bootstrap the bootstrap class
-	 */
-	protected $bootstrap;
-
 	/**
 	 * @var array the settings array
 	 */
@@ -36,7 +35,7 @@ class Core {
 	protected $pageRepository;
 
 	/**
-	 * @var null|\Phile\Model\Page the page model
+	 * @var null|Page the page model
 	 */
 	protected $page;
 
@@ -46,23 +45,29 @@ class Core {
 	protected $output;
 
 	/**
-	 * @var \Phile\Core\Response
+	 * @var \Phile\Core\Response the response the core send
 	 */
 	protected $response;
+
+	/**
+	 * @var string relative URL of current request
+	 */
+	protected $pageId;
 
 	/**
 	 * The constructor carries out all the processing in Phile.
 	 * Does URL routing, Markdown processing and Twig processing.
 	 *
-	 * @param Bootstrap $bootstrap
+	 * @param Response $response
+	 * @throws \Exception
 	 */
-	public function __construct(Bootstrap $bootstrap) {
-		$this->bootstrap = $bootstrap;
-
+	public function __construct(Response $response) {
 		$this->settings = \Phile\Registry::get('Phile_Settings');
 
+		$this->response = $response;
+		$this->response->setCharset($this->settings['charset']);
+
 		$this->pageRepository = new \Phile\Repository\Page();
-		$this->response = (new Response)->setCharset($this->settings['charset']);
 
 		// Setup Check
 		$this->checkSetup();
@@ -71,6 +76,7 @@ class Core {
 		$this->initializeErrorHandling();
 
 		// init current page
+		$this->resolveUrl();
 		$this->initializeCurrentPage();
 
 		// init template
@@ -83,35 +89,29 @@ class Core {
 	 * @return string
 	 */
 	public function render() {
-		return $this->response->send();
+		$this->response->send();
+	}
+
+	/**
+	 * detect URL, perform necessary redirects and resolve page-Id
+	 */
+	protected function resolveUrl() {
+		$url = Request::getUrl();
+		$tidy = Router::tidyUrl($url);
+		if ($url !== $tidy) {
+			$this->response->setStatusCode(301)->redirect(Router::url($tidy));
+			return;
+		}
+		Event::triggerEvent('request_uri', ['uri' => $url]);
+		$this->pageId = $url;
 	}
 
 	/**
 	 * initialize the current page
 	 */
 	protected function initializeCurrentPage() {
-		$uri = (strpos($_SERVER['REQUEST_URI'], '?') !== false) ? substr($_SERVER['REQUEST_URI'], 0, strpos($_SERVER['REQUEST_URI'], '?')) : $_SERVER['REQUEST_URI'];
-		$uri = str_replace('/' . \Phile\Utility::getInstallPath() . '/', '', $uri);
-		$uri = (strpos($uri, '/') === 0) ? substr($uri, 1) : $uri;
-
-		// strip '/index' if it exists (as per https://github.com/PhileCMS/Phile/pull/170)
-		if ($uri=="index" || preg_match("#/index$#", $uri)>0) {
-			// we can't just check if 'index' are the last 5 letters, because then URLs
-			// like 'example.com/blog/global-economic-index' would also be stripped...
-			$uri = rtrim(Utility::getBaseUrl() . '/' . substr($uri, 0, -5), '/');
-			Utility::redirect($uri, 301);
-		}
-
-		/**
-		 * @triggerEvent request_uri this event is triggered after the request uri is detected.
-		 *
-		 * @param uri the uri
-		 */
-		Event::triggerEvent('request_uri', array('uri' => $uri));
-
-		// use the current url to find the page
-		$page = $this->pageRepository->findByPath($uri);
-		if ($page instanceof \Phile\Model\Page) {
+		$page = $this->pageRepository->findByPath($this->pageId);
+		if ($page instanceof Page) {
 			$this->page = $page;
 		} else {
 			$this->response->setStatusCode(404);
@@ -155,8 +155,9 @@ class Core {
 		Event::triggerEvent('before_setup_check');
 
 		if (!isset($this->settings['encryptionKey']) || strlen($this->settings['encryptionKey']) == 0) {
-			if (strpos($_SERVER['REQUEST_URI'], '/setup') === false) {
-				Utility::redirect($this->settings['base_url'] . '/setup');
+			if (Request::getUrl() !== 'setup') {
+				$this->response->redirect(Router::url('setup'));
+				return;
 			}
 		} else {
 			if (is_file(CONTENT_DIR . 'setup.md')) {

--- a/lib/Phile/Core/Request.php
+++ b/lib/Phile/Core/Request.php
@@ -36,6 +36,8 @@ class Request {
 		$url = str_replace($basePath, '', $url);
 		$url = ltrim($url, '/');
 
+		$url = urldecode($url);
+
 		return $url;
 	}
 

--- a/lib/Phile/Core/Request.php
+++ b/lib/Phile/Core/Request.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * the Request class
+ */
+
+namespace Phile\Core;
+
+/**
+ * the Request class gives access to the incoming HTTP request
+ *
+ * @author PhileCMS
+ * @link https://philecms.com
+ * @license http://opensource.org/licenses/MIT
+ * @package Phile
+ */
+class Request {
+
+	/**
+	 * get request-URL relative to Phile base-URL
+	 *
+	 * @return string relative URL e.g. `index`, `sub/index`, `sub/page`
+	 */
+	public static function getUrl() {
+		$url = $_SERVER['REQUEST_URI'];
+
+		// remove query string
+		$queryPosition = strpos($url, '?');
+		if ($queryPosition) {
+			$url = substr($url, 0, $queryPosition);
+		}
+
+		// resolve root-relative URL-path
+		$baseUrl = Router::getBaseUrl();
+		$basePath = static::getUrlPath($baseUrl);
+		$url = str_replace($basePath, '', $url);
+		$url = ltrim($url, '/');
+
+		return $url;
+	}
+
+	/**
+	 * returns $key in the data send by GET or POST request
+	 *
+	 * @param string $key
+	 * @return null|string
+	 */
+	public static function getData($key) {
+		if (isset($_GET[$key])) {
+			$value = $_GET[$key];
+		} elseif (isset($_POST[$key])) {
+			$value = $_POST[$key];
+		} else {
+			return null;
+		}
+		$value = urldecode($value);
+		return $value;
+	}
+
+	/**
+	 * get the HTTP-protocol of the request
+	 *
+	 * @return string
+	 */
+	public static function getProtocol() {
+		if (empty($_SERVER['HTTP_HOST'])) {
+			return null;
+		}
+		$protocol = 'http';
+		if (isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') {
+			$protocol = 'https';
+		}
+		return $protocol;
+	}
+
+	/**
+	 * get path of an URL
+	 *
+	 * `scheme://host/path/sub` --> `/path/sub`
+	 *
+	 * @param string $url
+	 * @return string
+	 */
+	protected static function getUrlPath($url) {
+		$path = '';
+		if (strpos($url, '://') !== false) {
+			$parsed = parse_url($url);
+			if (isset($parsed['path'])) {
+				$path = $parsed['path'];
+			}
+		}
+		return $path;
+	}
+
+}

--- a/lib/Phile/Core/Response.php
+++ b/lib/Phile/Core/Response.php
@@ -1,9 +1,19 @@
 <?php
 
+/**
+ * the Response class
+ */
+
 namespace Phile\Core;
 
 /**
- * Response class implements HTTP response handling
+ * the Response class is responsible for sending a HTTP response to the client
+ *
+ * Response is chainable and can be used anywhere:
+ *
+ * 	(new Respose)->setBody('Hello World')->send();
+ *
+ * After send() Phile is terminated.
  *
  * @author PhileCMS
  * @link https://philecms.com
@@ -32,41 +42,94 @@ class Response {
 	 */
 	protected $statusCode = 200;
 
+	/**
+	 * redirect to another URL
+	 *
+	 * @param string $url URL
+	 */
+	public function redirect($url) {
+		if (strpos($this->statusCode, 3) !== 0) {
+			$this->setStatusCode(302);
+		}
+		$this->setHeader('Location', $url, true)
+			->setBody('')
+			->send()
+			->stop();
+	}
+
+	/**
+	 * set the response body
+	 *
+	 * @param $body
+	 * @return $this
+	 */
 	public function setBody($body) {
 		$this->body = $body;
 		return $this;
 	}
 
+	/**
+	 * set the response character-set
+	 *
+	 * @param $charset
+	 * @return $this
+	 */
 	public function setCharset($charset) {
 		$this->charset = $charset;
 		return $this;
 	}
 
 	/**
-	 * Set HTTP-header
+	 * set a response HTTP-header
 	 *
 	 * @param string $key
 	 * @param string $value
+	 * @param bool $clear clear out any existing headers
 	 * @return $this
 	 */
-	public function setHeader($key, $value) {
+	public function setHeader($key, $value, $clear = false) {
+		if ($clear) {
+			$this->headers = [];
+		}
 		$this->headers[$key] = "$key: $value";
 		return $this;
 	}
 
+	/**
+	 * set the response HTTP status code
+	 *
+	 * @param $code
+	 * @return $this
+	 */
 	public function setStatusCode($code) {
 		$this->statusCode = $code;
 		return $this;
 	}
 
+	/**
+	 * sends the HTTP response
+	 *
+	 * @return $this
+	 */
 	public function send() {
 		$this->setHeader('Content-Type',
 			'text/html; charset=' . $this->charset);
 		$this->outputHeader();
 		http_response_code($this->statusCode);
 		echo $this->body;
+		return $this;
 	}
 
+	/**
+	 * helper for easy testing
+	 */
+	protected function stop() {
+		die();
+	}
+
+	/**
+	 * output all set response headers
+	 */
 	protected function outputHeader() {
 		foreach ($this->headers as $header) {
 			header($header);

--- a/lib/Phile/Core/Response.php
+++ b/lib/Phile/Core/Response.php
@@ -1,76 +1,77 @@
 <?php
 
-  namespace Phile\Core;
+namespace Phile\Core;
 
-  /**
-   * Response class implements HTTP response handling
-   *
-   * @author PhileCMS
-   * @link https://philecms.com
-   * @license http://opensource.org/licenses/MIT
-   * @package Phile
-   */
-  class Response {
+/**
+ * Response class implements HTTP response handling
+ *
+ * @author PhileCMS
+ * @link https://philecms.com
+ * @license http://opensource.org/licenses/MIT
+ * @package Phile
+ */
+class Response {
 
-    /**
-     * @var string HTTP body
-     */
-    protected $body = '';
+	/**
+	 * @var string HTTP body
+	 */
+	protected $body = '';
 
-    /**
-     * @var string charset
-     */
-    protected $charset = 'utf-8';
+	/**
+	 * @var string charset
+	 */
+	protected $charset = 'utf-8';
 
-    /**
-     * @var array HTTP-headers
-     */
-    protected $headers = [];
+	/**
+	 * @var array HTTP-headers
+	 */
+	protected $headers = [];
 
-    /**
-     * @var int HTTP status code
-     */
-    protected $statusCode = 200;
+	/**
+	 * @var int HTTP status code
+	 */
+	protected $statusCode = 200;
 
-    public function setBody($body) {
-      $this->body = $body;
-      return $this;
-    }
+	public function setBody($body) {
+		$this->body = $body;
+		return $this;
+	}
 
-    public function setCharset($charset) {
-      $this->charset = $charset;
-      return $this;
-    }
+	public function setCharset($charset) {
+		$this->charset = $charset;
+		return $this;
+	}
 
-    /**
-     * Set HTTP-header
-     *
-     * @param string $key
-     * @param string $value
-     * @return $this
-     */
-    public function setHeader($key, $value) {
-      $this->headers[$key] = "$key: $value";
-      return $this;
-    }
+	/**
+	 * Set HTTP-header
+	 *
+	 * @param string $key
+	 * @param string $value
+	 * @return $this
+	 */
+	public function setHeader($key, $value) {
+		$this->headers[$key] = "$key: $value";
+		return $this;
+	}
 
-    public function setStatusCode($code) {
-      $this->statusCode = $code;
-      return $this;
-    }
+	public function setStatusCode($code) {
+		$this->statusCode = $code;
+		return $this;
+	}
 
-    public function send() {
-      $this->setHeader('Content-Type', 'text/html; charset=' . $this->charset);
-      $this->outputHeader();
-      http_response_code($this->statusCode);
-      echo $this->body;
-    }
+	public function send() {
+		$this->setHeader('Content-Type',
+			'text/html; charset=' . $this->charset);
+		$this->outputHeader();
+		http_response_code($this->statusCode);
+		echo $this->body;
+	}
 
-    protected function outputHeader() {
-      foreach ($this->headers as $header) {
-        header($header);
-      }
-    }
+	protected function outputHeader() {
+		foreach ($this->headers as $header) {
+			header($header);
+		}
+	}
 
-  }
+}
 

--- a/lib/Phile/Core/Router.php
+++ b/lib/Phile/Core/Router.php
@@ -81,6 +81,7 @@ class Router {
 	 */
 	public static function tidyUrl($url) {
 		$url = preg_replace('/(^|\/)index(\/)?$/', '', $url);
+		$url = rtrim($url, '/');
 		return $url;
 	}
 

--- a/lib/Phile/Core/Router.php
+++ b/lib/Phile/Core/Router.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * the Router class
+ */
+
+namespace Phile\Core;
+
+/**
+ * this Router class is responsible for Phile's basic URL management
+ *
+ * @package Phile\Core
+ */
+class Router {
+
+	/**
+	 * get the URL for a page-Id
+	 *
+	 * e.g. `sub/index` --> `http://host/phile-root/sub`
+	 *
+	 * @param string $pageId
+	 * @param bool $base return a full or root-relative URL
+	 * @return string URL
+	 */
+	public static function urlForPage($pageId, $base = true) {
+		$url = static::tidyUrl($pageId);
+		if ($base) {
+			$url = static::url($url);
+		}
+		return $url;
+	}
+
+	/**
+	 * converts Phile-root relative URL to full URL
+	 *
+	 * e.g. `foo/bar.ext` --> `http://host/phile-root/foo/bar.ext`
+	 *
+	 * @param string $url
+	 * @return string
+	 */
+	public static function url($url) {
+		return static::getBaseUrl() . '/' . ltrim($url, '/');
+	}
+
+	/**
+	 * Get base-URL of the Phile installation
+	 *
+	 * @return string `scheme://host/path/phile-root`
+	 */
+	public static function getBaseUrl() {
+		if (Registry::isRegistered('Phile_Settings')) {
+			$config = Registry::get('Phile_Settings');
+			if (isset($config['base_url']) && $config['base_url']) {
+				return $config['base_url'];
+			}
+		}
+
+		$scriptUrl = isset($_SERVER['PHP_SELF']) ? $_SERVER['PHP_SELF'] : '';
+		$url = str_replace('index.php', '', $scriptUrl);
+
+		if (!isset($_SERVER['HTTP_HOST'])) {
+			return $url;
+		}
+		$host = $_SERVER['HTTP_HOST'];
+		$protocol = Request::getProtocol();
+		if ($protocol) {
+			$url = $protocol . '://' . $host . $url;
+		}
+		$url = rtrim($url, '/');
+		return $url;
+	}
+
+	/**
+	 * convert URL to canonical Phile-URL
+	 *
+	 * - remove `/index` suffix (see #170)
+	 * - remove trailing slash
+	 *
+	 * @param string $url
+	 * @return string
+	 */
+	public static function tidyUrl($url) {
+		$url = preg_replace('/(^|\/)index(\/)?$/', '', $url);
+		return $url;
+	}
+
+}

--- a/lib/Phile/Core/Utility.php
+++ b/lib/Phile/Core/Utility.php
@@ -5,9 +5,9 @@
 namespace Phile\Core;
 
 /**
- * the Registry class for implementing a registry
+ * Utility class
  *
- * @author  Frank Nägler
+ * @author  PhileCMS
  * @link    https://philecms.com
  * @license http://opensource.org/licenses/MIT
  * @package Phile
@@ -15,54 +15,30 @@ namespace Phile\Core;
 class Utility {
 
 	/**
-	 * method to get the current http protocoll
+	 * method to get the current http protocol
 	 *
 	 * @return string the current protocol
+	 * @deprecated since 1.5 will be removed 1.6
 	 */
 	public static function getProtocol() {
-		if (PHILE_CLI_MODE) {
-			return '';
-		}
-		$protocol = 'http';
-		if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off' ) {
-			$protocol = 'https';
-		}
-
-		return $protocol;
+		return Request::getProtocol();
 	}
 
 	/**
 	 * detect base url
 	 *
 	 * @return string
+	 * @deprecated since 1.5 will be removed 1.6
 	 */
 	public static function getBaseUrl() {
-		if (PHILE_CLI_MODE) {
-			return '';
-		}
-		if (Registry::isRegistered('Phile_Settings')) {
-			$config = Registry::get('Phile_Settings');
-			if (isset($config['base_url']) && $config['base_url']) {
-				return $config['base_url'];
-			}
-		}
-
-		$url         = '';
-		$request_url = (isset($_SERVER['REQUEST_URI'])) ? $_SERVER['REQUEST_URI'] : '';
-		$script_url  = (isset($_SERVER['PHP_SELF'])) ? $_SERVER['PHP_SELF'] : '';
-		if ($request_url != $script_url) {
-			$url = trim(preg_replace('/' . str_replace('/', '\/', str_replace('index.php', '', $script_url)) . '/', '', $request_url, 1), '/');
-		}
-
-		$protocol = self::getProtocol();
-
-		return rtrim(str_replace($url, '', $protocol . "://" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']), '/');
+		return Router::getBaseUrl();
 	}
 
 	/**
 	 * detect install path
 	 *
 	 * @return string
+	 * @deprecated since 1.5 will be removed 1.6
 	 */
 	public static function getInstallPath() {
 		$path = self::getBaseUrl();
@@ -143,10 +119,11 @@ class Utility {
 	 *
 	 * @param     $url        the url to redirect to
 	 * @param int $statusCode the http status code
+	 * @deprecated since 1.5 will be removed 1.6
 	 */
 	public static function redirect($url, $statusCode = 302) {
-		header('Location: ' . $url, true, $statusCode);
-		die();
+		$response = new Response;
+		$response->setStatusCode($statusCode)->redirect($url);
 	}
 
 	/**

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -4,6 +4,7 @@
  */
 namespace Phile\Model;
 
+use Phile\Core\Router;
 use Phile\Event;
 use Phile\ServiceLocator;
 
@@ -42,9 +43,9 @@ class Page {
 	protected $parser;
 
 	/**
-	 * @var string returns the path of the page
+	 * @var string the pageId of the page
 	 */
-	protected $url;
+	protected $pageId;
 
 	/**
 	 * @var \Phile\Model\Page the previous page if one exist
@@ -166,26 +167,17 @@ class Page {
 	}
 
 	/**
-	 * Generate a pretty URL for the provided filename
+	 * get Phile $pageId
 	 *
 	 * @param string $filePath
 	 * @return string
 	 */
-	protected function buildUrl($filePath) {
-		$url = str_replace($this->contentFolder, '', $filePath);
-		$url = str_replace(CONTENT_EXT, '', $url);
-		$url = str_replace(DIRECTORY_SEPARATOR, '/', $url);
-
-		// strip '/index' from the URL (can't just check if last 5 letters are 'index',
-		// because then URL's like "example.com/blog/global-economic-index" would also
-		// be chopped...)
-		$url = preg_replace('#(.*)/index$#', '$1', $url);
-
-		// if the whole url is 'index', then drop that as well
-		$url = preg_replace('#^index$#', '', $url);
-		$url = ltrim($url, '/');
-
-		return $url;
+	protected function buildPageId($filePath) {
+		$pageId = str_replace($this->contentFolder, '', $filePath);
+		$pageId = str_replace(CONTENT_EXT, '', $pageId);
+		$pageId = str_replace(DIRECTORY_SEPARATOR, '/', $pageId);
+		$pageId = ltrim($pageId, '/');
+		return $pageId;
 	}
 
 	/**
@@ -194,7 +186,7 @@ class Page {
 	 * @return string
 	 */
 	public function getUrl() {
-		return $this->url;
+		return Router::urlForPage($this->pageId, false);
 	}
 
 	/**
@@ -204,7 +196,7 @@ class Page {
 	 */
 	public function setFilePath($filePath) {
 		$this->filePath = $filePath;
-		$this->url = $this->buildUrl($this->filePath);
+		$this->pageId = $this->buildPageId($this->filePath);
 	}
 
 	/**

--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -55,7 +55,6 @@ class Page {
 	 * @return null|\Phile\Model\Page
 	 */
 	public function findByPath($path, $folder = CONTENT_DIR) {
-		$path = str_replace(Utility::getInstallPath(), '', $path);
 		$fullPath =  str_replace(array("\\", "//", "\\/", "/\\"), DIRECTORY_SEPARATOR, $folder.$path);
 
 		$file = $fullPath . CONTENT_EXT;

--- a/tests/Phile/Core/RequestTest.php
+++ b/tests/Phile/Core/RequestTest.php
@@ -34,7 +34,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
 		$_GET['foo'] = 'bar';
 		$this->assertEquals(Request::getData('foo'), 'bar');
 
-		$_GET['baz'] = 'zap';
+		$_POST['baz'] = 'zap';
 		$this->assertEquals(Request::getData('baz'), 'zap');
 	}
 

--- a/tests/Phile/Core/RequestTest.php
+++ b/tests/Phile/Core/RequestTest.php
@@ -39,8 +39,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetUrl() {
-		$_SERVER['REQUEST_URI'] = '/bar/baz?q=a';
-		$this->assertEquals('bar/baz', Request::getUrl());
+		$_SERVER['REQUEST_URI'] = '/bar/b%C3%A4z%20page?q=a';
+		$this->assertEquals('bar/bäz page', Request::getUrl());
 	}
 
 	public function testGetProtocol() {

--- a/tests/Phile/Core/RequestTest.php
+++ b/tests/Phile/Core/RequestTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace PhileTest\Core;
+
+use Phile\Bootstrap;
+use Phile\Core\Registry;
+use Phile\Core\Request;
+
+/**
+ * the ResponseTest class
+ *
+ * @author  PhileCMS
+ * @link    https://philecms.com
+ * @license http://opensource.org/licenses/MIT
+ * @package PhileTest
+ */
+class RequestTest extends \PHPUnit_Framework_TestCase {
+
+	protected $baseUrl = 'http://foo';
+
+	public function setUp() {
+		Bootstrap::getInstance()->initializeBasics();
+		$settings = Registry::get('Phile_Settings');
+		Registry::set(
+			'Phile_Settings',
+			['base_url' => $this->baseUrl] + $settings
+		);
+		parent::setUp();
+	}
+
+	public function testGetData() {
+		$this->assertNull(Request::getData('zup'));
+
+		$_GET['foo'] = 'bar';
+		$this->assertEquals(Request::getData('foo'), 'bar');
+
+		$_GET['baz'] = 'zap';
+		$this->assertEquals(Request::getData('baz'), 'zap');
+	}
+
+	public function testGetUrl() {
+		$_SERVER['REQUEST_URI'] = '/bar/baz?q=a';
+		$this->assertEquals('bar/baz', Request::getUrl());
+	}
+
+	public function testGetProtocol() {
+		$this->assertEquals(null, Request::getProtocol());
+
+		$_SERVER ['HTTP_HOST'] = 'foo';
+
+		$this->assertEquals('http', Request::getProtocol());
+
+		$_SERVER['HTTPS'] = 'ON';
+		$this->assertEquals('https', Request::getProtocol());
+
+	}
+
+}

--- a/tests/Phile/Core/ResponseTest.php
+++ b/tests/Phile/Core/ResponseTest.php
@@ -5,48 +5,82 @@ namespace PhileTest\Core;
 use Phile\Core\Response;
 
 /**
-* the ResponseTest class
-*
-* @author  PhileCms
-* @link    https://philecms.com
-* @license http://opensource.org/licenses/MIT
-* @package PhileTest
-*/
+ * the ResponseTest class
+ *
+ * @author  PhileCms
+ * @link    https://philecms.com
+ * @license http://opensource.org/licenses/MIT
+ * @package PhileTest
+ */
 class ResponseTest extends \PHPUnit_Framework_TestCase {
 
-  /**
-   * @var \Phile\Core\Response
-   */
-  protected $response;
+	/**
+	 * @var \Phile\Core\Response
+	 */
+	protected $response;
 
-  protected function setUp() {
-    parent::setUp();
-    $this->response = $this->getMock('\Phile\Core\Response', ['outputHeader']);
-  }
+	protected function setUp() {
+		parent::setUp();
+		$this->response = $this->getMock(
+			'\Phile\Core\Response',
+			['outputHeader', 'stop']
+		);
+	}
 
-  protected function tearDown() {
-    unset($this->response);
-  }
+	protected function tearDown() {
+		unset($this->response);
+	}
 
-  public function testDefaultCharset() {
-    $this->response = $this->getMock('\Phile\Core\Response', ['setHeader']);
-    $this->response->expects($this->once())
-      ->method('setHeader')
-      ->with('Content-Type', 'text/html; charset=utf-8');
-    $this->response->send();
-  }
+	public function testDefaultCharset() {
+		$this->response = $this->getMock('\Phile\Core\Response',
+			['setHeader']);
+		$this->response->expects($this->once())
+			->method('setHeader')
+			->with('Content-Type', 'text/html; charset=utf-8');
+		$this->response->send();
+	}
 
-  public function testSetCharset() {
-    $this->response = $this->getMock('\Phile\Core\Response', ['setHeader']);
-    $this->response->expects($this->once())
-      ->method('setHeader')
-      ->with('Content-Type', 'text/html; charset=latin-1');
-    $this->response->setCharset('latin-1')->send();
-  }
+	public function testRedirect() {
+		$location = 'foo';
 
-  public function testSetBody() {
-    $this->response->setBody('foo')->send();
-    $this->expectOutputString('foo');
-  }
+		$this->response = $this->getMock(
+			'\Phile\Core\Response',
+			['setHeader', 'setStatusCode', 'send', 'stop']
+		);
+
+		$this->response->expects($this->once())
+			->method('setStatusCode')
+			->with('302')
+			->will($this->returnSelf());
+		$this->response->expects($this->once())
+			->method('setHeader')
+			->with('Location', $location, true)
+			->will($this->returnSelf());
+		$this->response->expects($this->once())
+			->method('send')
+			->will($this->returnSelf());
+		$this->response->expects($this->once())
+			->method('stop');
+
+		$this->response
+			->setBody('foo')
+			->redirect($location);
+
+		$this->expectOutputString('');
+	}
+
+	public function testSetCharset() {
+		$this->response = $this->getMock('\Phile\Core\Response',
+			['setHeader']);
+		$this->response->expects($this->once())
+			->method('setHeader')
+			->with('Content-Type', 'text/html; charset=latin-1');
+		$this->response->setCharset('latin-1')->send();
+	}
+
+	public function testSetBody() {
+		$this->response->setBody('foo')->send();
+		$this->expectOutputString('foo');
+	}
 
 }

--- a/tests/Phile/Core/RouterTest.php
+++ b/tests/Phile/Core/RouterTest.php
@@ -69,6 +69,9 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('foo-index', Router::tidyUrl('foo-index/'));
 		$this->assertEquals('foo-index', Router::tidyUrl('foo-index'));
+
+		$this->assertEquals('sub', Router::tidyUrl('sub/'));
+		$this->assertEquals('sub/page', Router::tidyUrl('sub/page/'));
 	}
 
 	public function mockBaseUrl($url) {

--- a/tests/Phile/Core/RouterTest.php
+++ b/tests/Phile/Core/RouterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace PhileTest\Core;
+
+use Phile\Core\Registry;
+use Phile\Core\Router;
+
+/**
+ * the Router class
+ *
+ * @author  PhileCMS
+ * @link    https://philecms.com
+ * @license http://opensource.org/licenses/MIT
+ * @package PhileTest
+ */
+class RouterTest extends \PHPUnit_Framework_TestCase {
+
+	protected $settings;
+
+	protected function setUp() {
+		$this->settings = Registry::get('Phile_Settings');
+		parent::setup();
+	}
+
+	protected function tearDown() {
+		Registry::set('Phile_Settings', $this->settings);
+		unset($this->settings);
+	}
+
+	public function testUrlForPageFull() {
+		$this->mockBaseUrl('http://barbaz');
+		$page = 'index/foo';
+		$expected = 'http://barbaz/index/foo';
+		$result = Router::urlForPage($page);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testUrlForPageRelative() {
+		$page = 'index/foo';
+		$expected = 'index/foo';
+		$result = Router::urlForPage($page, false);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testUrl() {
+		$this->mockBaseUrl('http://barbaz');
+		$expected = 'http://barbaz/sub/page';
+		$result = Router::url('sub/page');
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testGetBaseUrl() {
+		$this->mockBaseUrl(null);
+		// http://foo/bar/index.php
+		$_SERVER['PHP_SELF'] = '/bar/index.php';
+		$_SERVER['HTTP_HOST'] = 'foo';
+
+		$this->assertEquals('http://foo/bar', Router::getBaseUrl());
+	}
+
+	public function testGetBaseUrlPreset() {
+		$this->mockBaseUrl('https://barbaz');
+		$this->assertEquals('https://barbaz', Router::getBaseUrl());
+	}
+
+	public function testTidyUrl() {
+		$this->assertEquals('', Router::tidyUrl('index'));
+		$this->assertEquals('', Router::tidyUrl('index/'));
+
+		$this->assertEquals('foo-index', Router::tidyUrl('foo-index/'));
+		$this->assertEquals('foo-index', Router::tidyUrl('foo-index'));
+	}
+
+	public function mockBaseUrl($url) {
+		Registry::set(
+			'Phile_Settings',
+			['base_url' => $url] + $this->settings
+		);
+	}
+
+}

--- a/tests/Phile/CoreTest.php
+++ b/tests/Phile/CoreTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace PhileTest;
+
+use Phile\Core\Registry;
+use Phile\Core\Router;
+
+/**
+ * the CoreTest class
+ *
+ * @author  Phile CMS
+ * @link    https://philecms.com
+ * @license http://opensource.org/licenses/MIT
+ * @package PhileTest
+ */
+class CoreTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 *
+	 */
+	public function testInitializeCurrentPageTidyUrlRedirect() {
+		$baseUrl = 'http://foo';
+		$currentUrl = 'sub/';
+		$tidyUrl = 'sub';
+
+		$settings = Registry::get('Phile_Settings');
+		Registry::set('Phile_Settings', ['base_url' => $baseUrl] + $settings);
+
+		$Core = $this->getMockBuilder('Phile\Core')
+			->setMethods([
+				'checkSetup',
+				'initializeErrorHandling',
+				'initializeTemplate'
+			])
+			->disableOriginalConstructor()
+			->getMock();
+
+		$_SERVER['REQUEST_URI'] = $currentUrl;
+		$response = $this->getMock(
+			'\Phile\Core\Response',
+			['redirect', 'setStatusCode', 'stop']
+		);
+		$response
+			->expects($this->once())
+			->method('setStatusCode')
+			->with(301)
+			->will($this->returnValue($response));
+		$response
+			->expects($this->once())
+			->method('redirect')
+			->with($baseUrl . '/' . $tidyUrl);
+
+		$Core->__construct($response);
+	}
+
+	/**
+	 * tests redirect to setup page if setup is unfinished
+	 */
+	public function testCheckSetupRedirectToSetupPage() {
+		$settings = Registry::get('Phile_Settings');
+		Registry::set('Phile_Settings', ['encryptionKey' => ''] + $settings);
+
+		$_SERVER['REQUEST_URI'] = '/';
+		$response = $this->getMock('\Phile\Core\Response', ['redirect']);
+		$response->expects($this->once())
+			->method('redirect')
+			->with(Router::url('setup'));
+
+		new \Phile\Core($response);
+	}
+}


### PR DESCRIPTION
Here's my take on cleaning up `Phile\Core::initializeCurrentPage()`, URL-redirecting and URL to Page conversion.

- a new static `Core\Router` class handling URL management
- a new static `Core\Request` class giving access to the current request
- a new method `Core\Response::redirect()`

Those classes should improve separation of concerns, allow testing and provide cleaner code while hopfully keeping Phile lightweight and accessible.

Methods which were moved from `Core\Utility` to the new classes are marked deprecated. 

The PR also includes the solution to #175 and #192 to show how those could be addressed in these new classes.

---

`Core::initializeCurrentPage()` itself was split up into `Core::resolveUrl()` and `Core::initializeCurrentPage()`.

There's now a notion of decoupling URL (request) and file-path (current Repository/Model). As intermediary serves a *page-Id*. The core resolves URL → page-Id and then passes page-Id → Repository to retrieve content. 

The repository should never have to touch URLs to resolve its content. The core should never  be concerned how the repository produces content for a particular page-Id.

That said: `Model\Page::getUrl()` still is alive and kicking. ;)

---

Because these are major changes a lively discussion is appreciated. :)
