### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+build.xml export-ignore
+Icon.png export-ignore
+phing export-ignore
+tests/ export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.editorconfig export-ignore
+.gitmessage export-ignore
+.travis export-ignore


### PR DESCRIPTION
With `.gitattributes` it's now easy to package the repository. The problem with installing it through composer is that it includes the entire contents of the git branch, including potentially undesirable files such as `tests/` and `.travis.yml`. I've therefore added a `.gitattributes` which will ignore this kind of files when creating a new Phile-project through composer.

These files are also ignored when zipping the repository.

Also check out the man page:

    $ man gitattributes