### PR TITLE
add new events to core

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -123,6 +123,15 @@ this event is triggered after the plugins loaded
 
 this event is triggered after the configuration is fully loaded
 
+#### after\_init\_core
+
+this event is triggered after the core is initialized
+
+| param                   | type                 | description                                                      |
+| ----------------------- |:---------------------|:-----------------------------------------------------------------|
+| `response`              | \Phile\Core\Response | the response                                                     |  
+
+
 #### request_uri
 
 this event is triggered after the request uri is detected.
@@ -130,6 +139,20 @@ this event is triggered after the request uri is detected.
 | param                   | type                               | description                                                          |
 | ----------------------- |:-----------------------------------|:---------------------------------------------------------------------|
 | `uri`                   | string                             | the requested uri (without install_path)                             |
+
+#### after\_404
+
+this event is triggered after a requested page is not found
+
+#### after\_resolve\_page
+
+this event is triggered after a request is resolved to a page
+
+| param                   | type                               | description                                                          |
+| ----------------------- |:-----------------------------------|:---------------------------------------------------------------------|
+| `pageId`                | string                             | the requested page-ID                                                |  
+| `page`                  | Phile\Model\Page                   | the page served                                                      |
+
 
 #### before\_init\_template
 


### PR DESCRIPTION
I want to introduce a few new events:

- after core init: access the response (e.g. change status code from 404 to 200 to serve different content on 404)
- after 404: detect when a 404 happened
- after resolve page: detect which page was requested and which page is actually served as main page

What above offers is possible at the moment by parsing and comparing file-paths and/or urls, derive it from other events, sending a complete new response etc. 

But imho those events would make life for plugins a lot easier because they are more explicit.