### PR TITLE
[FIX] append file extensions on `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,6 @@ tests/ export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .editorconfig export-ignore
-.gitmessage export-ignore
-.travis export-ignore
+.gitmessage.txt export-ignore
+.travis.yml export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
Some dev files were not excluded when downloading a `.zip` because it was missing the file extension.

Related: #200