### PR TITLE
allow callable as Event::register objects

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -123,6 +123,10 @@ this event is triggered after the plugins loaded
 
 this event is triggered after the configuration is fully loaded
 
+| param                   | type                               | description                                                          |
+| ----------------------- |:-----------------------------------|:---------------------------------------------------------------------|
+| `config`                | array                              | the complete configuration                                           |
+
 #### request_uri
 
 this event is triggered after the request uri is detected.

--- a/lib/Phile/Bootstrap.php
+++ b/lib/Phile/Bootstrap.php
@@ -175,7 +175,7 @@ class Bootstrap {
 
 		// settings now include initialized plugin-configs
 		$this->settings = Registry::get('Phile_Settings');
-		Event::triggerEvent('config_loaded');
+		Event::triggerEvent('config_loaded', ['config' => $this->settings]);
 	}
 
 	/**

--- a/lib/Phile/Core/Event.php
+++ b/lib/Phile/Core/Event.php
@@ -38,9 +38,6 @@ class Event {
 				1427814905
 			);
 		}
-		if (!isset(self::$_registry[$eventName])) {
-			self::$_registry[$eventName] = [];
-		}
 		self::$_registry[$eventName][] = $object;
 	}
 

--- a/lib/Phile/Core/Event.php
+++ b/lib/Phile/Core/Event.php
@@ -29,8 +29,14 @@ class Event {
 	 * @param EventObserverInterface|callable $object observer
 	 */
 	public static function registerEvent($eventName, $object) {
-		if (!($object instanceof EventObserverInterface) && !is_callable($object)) {
-			throw new \InvalidArgumentException;
+		if ($object instanceof EventObserverInterface) {
+			$object = [$object, 'on'];
+		}
+		if (!is_callable($object)) {
+			throw new \InvalidArgumentException(
+				"Can't register event. Observer is not callable.",
+				1427814905
+			);
 		}
 		if (!isset(self::$_registry[$eventName])) {
 			self::$_registry[$eventName] = [];
@@ -49,9 +55,6 @@ class Event {
 			return;
 		}
 		foreach (self::$_registry[$eventName] as $observer) {
-			if ($observer instanceof EventObserverInterface) {
-				$observer = [$observer, 'on'];
-			}
 			call_user_func_array($observer, [$eventName, $data]);
 		}
 	}

--- a/tests/Phile/EventTest.php
+++ b/tests/Phile/EventTest.php
@@ -46,4 +46,10 @@ class EventTest extends \PHPUnit_Framework_TestCase {
 		Event::registerEvent('myTestEvent2', $callable);
 		Event::triggerEvent('myTestEvent2');
 	}
+
+	public function testRegisterFail() {
+		$this->setExpectedException('\InvalidArgumentException');
+		Event::registerEvent('myTestEvent2', new \stdClass());
+	}
+
 }

--- a/tests/Phile/EventTest.php
+++ b/tests/Phile/EventTest.php
@@ -8,6 +8,8 @@
 
 namespace PhileTest;
 
+use Phile\Core\Event;
+
 
 /**
  * the EventTest class
@@ -27,8 +29,21 @@ class EventTest extends \PHPUnit_Framework_TestCase {
 		$mock->expects($this->once())
 			->method('on');
 
-		\Phile\Core\Event::registerEvent('myTestEvent', $mock);
-		\Phile\Core\Event::triggerEvent('myTestEvent');
+		Event::registerEvent('myTestEvent', $mock);
+		Event::triggerEvent('myTestEvent');
+	}
+
+	public function testRegisterAndTriggerCallback() {
+		$mock = $this->getMock('stdClass', ['foo']);
+		$mock->expects($this->exactly(2))->method('foo');
+
+		Event::registerEvent('myTestEvent', [$mock, 'foo']);
+		Event::triggerEvent('myTestEvent');
+
+		$callable = function () use ($mock) {
+			$mock->foo();
+		};
+		Event::registerEvent('myTestEvent2', $callable);
+		Event::triggerEvent('myTestEvent2');
 	}
 }
- 


### PR DESCRIPTION
Extends the Event::register to also accept callables:

```php
Event::registerEvent('before_foo', function($data) { … } );
// or
Event::registerEvent('before_foo', [$myClassInstance, 'method']);
```