### PR TITLE
twig template class internal refactoring

### DIFF
--- a/lib/Phile/Core.php
+++ b/lib/Phile/Core.php
@@ -127,6 +127,10 @@ class Core {
 		 */
 		Event::triggerEvent('before_setup_check');
 
+		if (!Registry::isRegistered('templateVars')) {
+			Registry::set('templateVars', []);
+		}
+
 		if (!isset($this->settings['encryptionKey']) || strlen($this->settings['encryptionKey']) == 0) {
 			if ($this->router->getCurrentUrl() !== 'setup') {
 				$this->response->redirect($this->router->url('setup'));
@@ -137,14 +141,6 @@ class Core {
 				unlink(CONTENT_DIR . 'setup.md');
 			}
 		}
-		if (Registry::isRegistered('templateVars')) {
-			$templateVars = Registry::get('templateVars');
-		} else {
-			$templateVars = array();
-		}
-		$templateVars['setup_enrcyptionKey'] = Utility::generateSecureToken(64);
-		Registry::set('templateVars', $templateVars);
-
 		/**
 		 * @triggerEvent after_setup_check this event is triggered after the setup check
 		 */
@@ -181,4 +177,5 @@ class Core {
 		Event::triggerEvent('after_render_template', array('templateEngine' => &$templateEngine, 'output' => &$output));
 		$this->response->setBody($output);
 	}
+
 }

--- a/plugins/phile/templateTwig/Classes/Template/Twig.php
+++ b/plugins/phile/templateTwig/Classes/Template/Twig.php
@@ -156,11 +156,8 @@ class Twig implements TemplateInterface {
 	 * @throws \Exception
 	 */
 	protected function getTemplateVars() {
-		/** @var array $templateVars */
-		$templateVars = Registry::get('templateVars');
-
 		$repository = new Repository($this->settings);
-		$templateVars += [
+		$defaults = [
 			'content' => $this->page->getContent(),
 			'meta' => $this->page->getMeta(),
 			'current_page' => $this->page,
@@ -174,6 +171,10 @@ class Twig implements TemplateInterface {
 			'theme_dir' => THEMES_DIR . $this->settings['theme'],
 			'theme_url' => $this->settings['base_url'] . '/' . basename(THEMES_DIR) . '/' . $this->settings['theme'],
 		];
+
+		/** @var array $templateVars */
+		$templateVars = Registry::get('templateVars');
+		$templateVars += $defaults;
 
 		return $templateVars;
 	}


### PR DESCRIPTION
This allows easy subclassing of `Phile\Plugin\Phile\TemplateTwig\Template` to implement other engines. You only have to overwrite `getEngine()` and `_render()`.

There are better ways to implement it (e.g. abstract class), but I didn't want to introduce something new and/or break backwards-compatibility.