### PR TITLE
remove conflicting 'use' statements from \Phile core

### DIFF
--- a/lib/Phile/Bootstrap.php
+++ b/lib/Phile/Bootstrap.php
@@ -4,9 +4,6 @@
  */
 namespace Phile;
 
-use Phile\Core\Event;
-use Phile\Core\Registry;
-use Phile\Core\Utility;
 use Phile\Exception\PluginException;
 use Phile\Plugin\PluginRepository;
 

--- a/lib/Phile/Core.php
+++ b/lib/Phile/Core.php
@@ -4,13 +4,8 @@
  */
 namespace Phile;
 
-use Phile\Core\Event;
-use Phile\Core\Registry;
-use Phile\Core\Request;
 use Phile\Core\Response;
 use Phile\Core\Router;
-use Phile\Core\ServiceLocator;
-use Phile\Core\Utility;
 use Phile\Model\Page;
 use Phile\Repository\Page as Repository;
 


### PR DESCRIPTION
- Regression from 1.5.0
- follow-up to #234 