### PR TITLE
add method Model\Page::getPlainContent()

### DIFF
--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -130,11 +130,11 @@ class Page {
 	}
 
 	/**
-	 * get plain (un-parsed) page content
+	 * get raw (un-parsed) page content
 	 *
 	 * @return string
 	 */
-	public function getPlainContent() {
+	public function getRawContent() {
 		return $this->content;
 	}
 

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -130,6 +130,15 @@ class Page {
 	}
 
 	/**
+	 * get plain (un-parsed) page content
+	 *
+	 * @return string
+	 */
+	public function getPlainContent() {
+		return $this->content;
+	}
+
+	/**
 	 * get the meta model
 	 *
 	 * @return Meta

--- a/tests/Phile/Model/PageTest.php
+++ b/tests/Phile/Model/PageTest.php
@@ -78,6 +78,15 @@ class PageTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 *
 	 */
+	public function testPageGetUnparsedContent() {
+		$page = $this->pageRepository->findByPath('/');
+		$page->setContent('*test*');
+		$this->assertEquals('*test*', $page->getPlainContent());
+	}
+
+	/**
+	 *
+	 */
 	public function testPageHasMetaObject() {
 		$page = $this->pageRepository->findByPath('/');
 		$this->assertInstanceOf('\Phile\Model\Meta', $page->getMeta());

--- a/tests/Phile/Model/PageTest.php
+++ b/tests/Phile/Model/PageTest.php
@@ -78,10 +78,10 @@ class PageTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 *
 	 */
-	public function testPageGetUnparsedContent() {
+	public function testPageGetRawContent() {
 		$page = $this->pageRepository->findByPath('/');
 		$page->setContent('*test*');
-		$this->assertEquals('*test*', $page->getPlainContent());
+		$this->assertEquals('*test*', $page->getRawContent());
 	}
 
 	/**


### PR DESCRIPTION
Introduces a `Model\Page::getPlainContent()` which returns the unparsed page content.

The existing `Model\Page::getContent()` is O.K. for the core but often not very well suited for plugins:

- result is parsed (HTML tags not desired/needed, performance impact)
- triggers parser events (side effects, potential for endless recursion)

I'm not particularly happy with the method name, so if someone has a better idea?