### PR TITLE
don't strip base-path from page-path in Core\Router::getCurrentUrl()

### DIFF
--- a/lib/Phile/Core/Router.php
+++ b/lib/Phile/Core/Router.php
@@ -47,7 +47,9 @@ class Router {
 		// resolve root-relative URL-path
 		$baseUrl = $this->getBaseUrl();
 		$basePath = $this->getUrlPath($baseUrl);
-		$url = str_replace($basePath, '', $url);
+		if (!empty($basePath) && strpos($url, $basePath) === 0) {
+			$url = substr($url, strlen($basePath));
+		}
 		$url = ltrim($url, '/');
 
 		$url = urldecode($url);

--- a/tests/Phile/Core/RouterTest.php
+++ b/tests/Phile/Core/RouterTest.php
@@ -83,9 +83,27 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('https://barbaz', $this->router->getBaseUrl());
 	}
 
-	public function testGetUrl() {
+	/**
+	 * test that URL is UTF8-decoded
+	 */
+	public function testGetUrlUrlDecoded() {
 		$router = new Router(['REQUEST_URI' => '/bar/b%C3%A4z%20page?q=a']);
 		$this->assertEquals('bar/bäz page', $router->getCurrentUrl());
+	}
+
+	/**
+	 * test that base-URL is removed
+	 */
+	public function testGetUrlRemoveUrlPath() {
+		$pathFragment = 'sub';
+		// assume installation in http://localhost/sub
+		$this->mockBaseUrl('http://localhost/' . $pathFragment);
+
+		// incoming request-URI: /sub/sub/page
+		$requestUri = '/' . $pathFragment . '/' . $pathFragment . '/page';
+		$router = new Router(['REQUEST_URI' => $requestUri]);
+		// requested page: sub/page.md
+		$this->assertEquals('sub/page', $router->getCurrentUrl());
 	}
 
 	public function testGetProtocol() {


### PR DESCRIPTION
fixes #245

It's the suggested solution wrapped into an additional check. Pretty sure that check isn't strictly necessary, but I feel better having it.