### PR TITLE
refactor plugin loading

### DIFF
--- a/default_config.php
+++ b/default_config.php
@@ -62,7 +62,7 @@ $config['plugins'] = [
 	 */
 	'phile\\errorHandler' => [
 		'active' => true,
-		'handler' => \Phile\Plugin\Phile\ErrorHandler\Plugin::HANDLER_DEVELOPMENT
+		'handler' => 'development'
 	],
 	/**
 	 * setup check

--- a/lib/Phile/Plugin/PluginRepository.php
+++ b/lib/Phile/Plugin/PluginRepository.php
@@ -14,11 +14,31 @@ use Phile\Exception\PluginException;
  */
 class PluginRepository {
 
-	/** @var array of AbstractPlugin */
+	/**
+	 * @var array of AbstractPlugin
+	 */
 	protected $plugins = [];
 
-	/** @var array errors during load; keys: 'message' and 'code' */
+	/**
+	 * @var array errors during load; keys: 'message' and 'code'
+	 */
 	protected $loadErrors = [];
+
+	/**
+	 * @var string path to plugin folder for this repository
+	 */
+	protected $folder;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $folder path to plugin folder
+	 */
+	public function __construct($folder) {
+		$this->folder = $folder;
+		spl_autoload_register([$this, 'autoload']);
+		return $this;
+	}
 
 	/**
 	 * get load errors
@@ -37,7 +57,6 @@ class PluginRepository {
 	 * @throws PluginException
 	 */
 	public function loadAll($settings) {
-		$this->reset();
 		foreach ($settings as $pluginKey => $config) {
 			if (!isset($config['active']) || !$config['active']) {
 				continue;
@@ -57,7 +76,7 @@ class PluginRepository {
 	/**
 	 * load and return single plugin
 	 *
-	 * @param $pluginKey
+	 * @param string $pluginKey
 	 * @return AbstractPlugin
 	 * @throws PluginException
 	 */
@@ -87,19 +106,11 @@ class PluginRepository {
 	}
 
 	/**
-	 * clear out repository
-	 */
-	protected function reset() {
-		$this->loadErrors = [];
-		$this->plugins = [];
-	}
-
-	/**
-	 * auto-loader plugin namespace
+	 * Auto-loader plugin namespace
 	 *
-	 * @param $className
+	 * @param string $className
 	 */
-	public static function autoload($className) {
+	public function autoload($className) {
 		if (strpos($className, "Phile\\Plugin\\") !== 0) {
 			return;
 		}
@@ -114,12 +125,9 @@ class PluginRepository {
 		);
 
 		$path = implode(DS, $classPath) . '.php';
-		foreach ([PLUGINS_DIR, PLUGINS_CORE_DIR] as $pluginDir) {
-			$fileName = $pluginDir . $path;
-			if (file_exists($fileName)) {
-				require_once $fileName;
-			}
+		$fileName = $this->folder . $path;
+		if (file_exists($fileName)) {
+			require_once $fileName;
 		}
 	}
-
 }

--- a/lib/Phile/Plugin/PluginRepository.php
+++ b/lib/Phile/Plugin/PluginRepository.php
@@ -37,7 +37,6 @@ class PluginRepository {
 	public function __construct($folder) {
 		$this->folder = $folder;
 		spl_autoload_register([$this, 'autoload']);
-		return $this;
 	}
 
 	/**

--- a/tests/Phile/Plugin/PluginRepositoryTest.php
+++ b/tests/Phile/Plugin/PluginRepositoryTest.php
@@ -16,7 +16,7 @@ class PluginRepositoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testLoadAllSuccess() {
 		$toLoad = 'phile\testPlugin';
-		$plugins = new PluginRepository();
+		$plugins = new PluginRepository(PLUGINS_CORE_DIR);
 
 		$result = $plugins->loadAll([$toLoad => ['active' => true]]);
 		$this->assertTrue(is_array($result));
@@ -27,7 +27,7 @@ class PluginRepositoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testLoadAllFailure() {
-		$plugins = new PluginRepository();
+		$plugins = new PluginRepository(PLUGINS_CORE_DIR);
 
 		$plugins->loadAll(['foo\\bar' => ['active' => false]]);
 		$this->assertEquals(0, count($plugins->getLoadErrors()));
@@ -35,5 +35,4 @@ class PluginRepositoryTest extends \PHPUnit_Framework_TestCase {
 		$plugins->loadAll(['foo\\bar' => ['active' => true]]);
 		$this->assertEquals(1, count($plugins->getLoadErrors()));
 	}
-
 }


### PR DESCRIPTION
Removes hardcoded directory paths from Plugin\PluginRepository and allows it to load and register arbitrary plugin-folders. Folder path is passed as constructor-dependency.

First and foremost: cleaner implementation. Theoretically also opens the door for providing plugins within plugins, but let's not go there officially. :wink:

Accessing plugin classes in the config.php is not longer possible. Imho that's reasonable. The only place where I ever have seen this used is Phile's own error handler. On the other hand it makes the implementation more murky having a plugin available before even the plugin-config is declared. If someone *really* needs that it's always possible to register a plugin in the composer.json manually (or to talk about it again later).

