### PR TITLE
allow empty/missing meta header in page

### DIFF
--- a/plugins/phile/parserMeta/Classes/Parser/Meta.php
+++ b/plugins/phile/parserMeta/Classes/Parser/Meta.php
@@ -34,17 +34,24 @@ class Meta implements MetaInterface {
 	 * parse the content and extract meta information
 	 *
 	 * @param string $rawData raw page data
-	 *
 	 * @return array with key/value store
 	 */
 	public function parse($rawData) {
 		$rawData = trim($rawData);
-		$START   = (substr($rawData, 0, 2) == '/*') ? '/*' : '<!--';
-		$END     = (substr($rawData, 0, 2) == '/*') ? '*/' : '-->';
 
-		$meta = trim(substr($rawData, strlen($START), strpos($rawData, $END) - (strlen($END) + 1)));
+		$start = substr($rawData, 0, 4);
+		if ($start === '<!--') {
+			$stop = '-->';
+		} elseif (substr($start, 0, 2) === '/*') {
+			$start = '/*';
+			$stop = '*/';
+		} else {
+			return [];
+		}
+
+		$meta = trim(substr($rawData, strlen($start), strpos($rawData, $stop) - (strlen($stop) + 1)));
 		$meta = Yaml::parse($meta);
-		$meta = $this->convertKeys($meta);
+		$meta = ($meta === null) ? [] : $this->convertKeys($meta);
 		return $meta;
 	}
 

--- a/tests/Phile/Model/MetaTest.php
+++ b/tests/Phile/Model/MetaTest.php
@@ -61,6 +61,12 @@ Date: 2014-08-01
 		$this->assertEquals('1st Aug 2014', $meta2->getFormattedDate());
 	}
 
+	public function testGetIfNotMetaDataOnPage() {
+		$meta = new \Phile\Model\Meta('…');
+		$this->assertEquals([], $meta->getAll());
+		$this->assertNull($meta->get('title'));
+	}
+
 	public function testSpacedKey() {
 		$meta = new \Phile\Model\Meta($this->metaTestData1);
 		$this->assertEquals('Should become underscored', $meta->get('spaced_key'));

--- a/tests/Phile/Model/MetaTest.php
+++ b/tests/Phile/Model/MetaTest.php
@@ -61,10 +61,13 @@ Date: 2014-08-01
 		$this->assertEquals('1st Aug 2014', $meta2->getFormattedDate());
 	}
 
-	public function testGetIfNotMetaDataOnPage() {
-		$meta = new \Phile\Model\Meta('…');
+	public function testGetIfNoMetaDataOnPage() {
+		$meta = new \Phile\Model\Meta("Welcome\n…");
 		$this->assertEquals([], $meta->getAll());
 		$this->assertNull($meta->get('title'));
+
+		$meta = new \Phile\Model\Meta("/*\n*/\nWelcome\n…");
+		$this->assertEquals([], $meta->getAll());
 	}
 
 	public function testSpacedKey() {


### PR DESCRIPTION
In 1.5- if no meta information is provided the parser fails silently and fills the meta tags with page content.

But since #259 an exception may be thrown.