### PR TITLE
add a method to get the PageCollection as array

### DIFF
--- a/lib/Phile/Repository/PageCollection.php
+++ b/lib/Phile/Repository/PageCollection.php
@@ -41,6 +41,16 @@ class PageCollection implements \ArrayAccess, \IteratorAggregate, \Countable {
 		}
 	}
 
+	/**
+	 * Get pages in a array.
+	 *
+	 * @return array of \Phile\Model\Page
+	 */
+	public function toArray() {
+		$this->load();
+		return $this->pages;
+	}
+
 	public function getIterator() {
 		$this->load();
 		return new \ArrayIterator($this->pages);

--- a/lib/Phile/Repository/PageCollection.php
+++ b/lib/Phile/Repository/PageCollection.php
@@ -2,7 +2,6 @@
 
 namespace Phile\Repository;
 
-
 /**
  * Page collection which delays searching for and loading pages until necessary.
  *
@@ -22,42 +21,42 @@ class PageCollection implements \ArrayAccess, \IteratorAggregate, \Countable {
 	 */
 	private	$pages;
 
-	public function	__construct($loader){
-		$this->loader =	$loader;
+	public function __construct($loader) {
+		$this->loader = $loader;
 	}
 
-	private	function load(){
-		if ($this->pages === null){
+	private function load() {
+		if ($this->pages === null) {
 			$this->pages = call_user_func($this->loader);
 		}
 	}
 
-	public function	getIterator(){
+	public function getIterator() {
 		$this->load();
 		return new \ArrayIterator($this->pages);
 	}
 
-	public function	offsetExists ($offset){
+	public function offsetExists($offset) {
 		$this->load();
 		return isset($this->pages[$offset]);
 	}
 
-	public function	offsetGet($offset){
+	public function	offsetGet($offset) {
 		$this->load();
 		return $this->pages[$offset];
 	}
 
-	public function	offsetSet($offset, $value){
+	public function	offsetSet($offset, $value) {
 		$this->load();
 		$this->pages[$offset] =	$value;
 	}
 
-	public function	offsetUnset($offset){
+	public function	offsetUnset($offset) {
 		$this->load();
 		unset($this->pages[$offset]);
 	}
 
-	public function	count(){
+	public function	count() {
 		$this->load();
 		return count($this->pages);
 	}

--- a/lib/Phile/Repository/PageCollection.php
+++ b/lib/Phile/Repository/PageCollection.php
@@ -17,14 +17,24 @@ class PageCollection implements \ArrayAccess, \IteratorAggregate, \Countable {
 	private	$loader;
 
 	/**
-	 * @var \Phile\Model\Page[] Array of loaded pages.
+	 * @var array of \Phile\Model\Page
 	 */
 	private	$pages;
 
-	public function __construct($loader) {
+	/**
+	 * Constructor.
+	 *
+	 * @param callable $loader pages loader
+	 */
+	public function __construct(callable $loader) {
 		$this->loader = $loader;
 	}
 
+	/**
+	 * Perform page loading.
+	 *
+	 * @return void
+	 */
 	private function load() {
 		if ($this->pages === null) {
 			$this->pages = call_user_func($this->loader);

--- a/tests/Phile/Repository/PageCollectionTest.php
+++ b/tests/Phile/Repository/PageCollectionTest.php
@@ -42,4 +42,9 @@ class PageCollectionTest extends \PHPUnit_Framework_TestCase {
 			$this->assertEquals($this->fixture[$key], $value);
 		}
 	}
+
+	public function testToArray() {
+		$result = $this->collection->toArray();
+		$this->assertEquals($this->fixture, $result);
+	}
 }

--- a/tests/Phile/Repository/PageCollectionTest.php
+++ b/tests/Phile/Repository/PageCollectionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Phile\Repository\PageCollection;
+
+/**
+ * the PageCollectionTest class
+ *
+ * @author  PhileCMS
+ * @link    https://philecms.com
+ * @license http://opensource.org/licenses/MIT
+ */
+class PageCollectionTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var PageCollection;
+	 */
+	protected $collection;
+
+	protected $fixture = [0 => 'a', 1 => 'b'];
+
+	protected function setUp() {
+		$loader = function () {
+			return $this->fixture;
+		};
+		$this->collection = new PageCollection($loader);
+	}
+
+	public function testArrayAccess() {
+		$result = $this->collection;
+		$this->assertEquals($this->fixture[0], $result[0]);
+		$this->assertEquals($this->fixture[1], $result[1]);
+	}
+
+	public function testCount() {
+		$result = $this->collection;
+		$this->assertEquals(count($this->fixture), count($result));
+	}
+
+	public function testTraversable() {
+		$result = $this->collection;
+		foreach ($result as $key => $value) {
+			$this->assertEquals($this->fixture[$key], $value);
+		}
+	}
+}


### PR DESCRIPTION
The page collection object is not fully backwards compatible to the raw array in Phile 1.5. So we should provide a official way to get an array out of it.