### PR TITLE
make YAML meta-tag parser not default yet

### DIFF
--- a/default_config.php
+++ b/default_config.php
@@ -75,7 +75,19 @@ $config['plugins'] = [
 	/**
 	 * meta-tag parser
 	 */
-	'phile\\parserMeta' => ['active' => true],
+	'phile\\parserMeta' => [
+		'active' => true,
+		/**
+		 * Set meta-data format.
+		 *
+		 * - 'Phile' (default) Phile legacy format
+		 * - 'YAML' YAML
+		 *
+		 * Phile is going to switch to YAML for parsing meta tags. But if you
+		 * want to use YAML today you can change the format here.
+		 */
+		 'format' => 'Phile'
+	],
 	/**
 	 * template engine
 	 */

--- a/plugins/phile/parserMeta/Classes/Parser/Meta.php
+++ b/plugins/phile/parserMeta/Classes/Parser/Meta.php
@@ -107,7 +107,6 @@ class Meta implements MetaInterface {
 			$parts = array_map('trim', $parts);
 			$meta[$parts[0]] = $parts[1];
 		}
-		$meta = $this->convertKeys($meta);
 		return $meta;
 	}
 }

--- a/plugins/phile/parserMeta/Classes/Parser/Meta.php
+++ b/plugins/phile/parserMeta/Classes/Parser/Meta.php
@@ -50,7 +50,11 @@ class Meta implements MetaInterface {
 		}
 
 		$meta = trim(substr($rawData, strlen($start), strpos($rawData, $stop) - (strlen($stop) + 1)));
-		$meta = Yaml::parse($meta);
+		if (strtolower($this->config['format']) === 'yaml') {
+			$meta = Yaml::parse($meta);
+		} else {
+			$meta = $this->parsePhileFormat($meta);
+		}
 		$meta = ($meta === null) ? [] : $this->convertKeys($meta);
 		return $meta;
 	}
@@ -79,5 +83,31 @@ class Meta implements MetaInterface {
 			$return[$newKey] = $value;
 		}
 		return $return;
+	}
+
+	/**
+	 * Phile meta format parser.
+	 *
+	 * @param string $string unparsed meta-data
+	 * @return array|null array with meta-tags; null: on meta-data found
+	 *
+	 * @deprecated since 1.6.0 Phile is going to switch to YAML
+	 */
+	protected function parsePhileFormat($string) {
+		if (empty($string)) {
+			return null;
+		}
+		$meta = [];
+		$lines = explode("\n", $string);
+		foreach ($lines as $line) {
+			$parts = explode(':', $line, 2);
+			if (count($parts) !== 2) {
+				continue;
+			}
+			$parts = array_map('trim', $parts);
+			$meta[$parts[0]] = $parts[1];
+		}
+		$meta = $this->convertKeys($meta);
+		return $meta;
 	}
 }

--- a/tests/Phile/Model/MetaTest.php
+++ b/tests/Phile/Model/MetaTest.php
@@ -74,9 +74,4 @@ Date: 2014-08-01
 		$meta = new \Phile\Model\Meta($this->metaTestData1);
 		$this->assertEquals('Should become underscored', $meta->get('spaced_key'));
 	}
-
-	public function testNested() {
-		$meta = new \Phile\Model\Meta($this->metaTestData1);
-		$this->assertEquals(['nested_a' => 1, 'nested_b' => 2], $meta->get('nested'));
-	}
 }


### PR DESCRIPTION
While I don't think there're major issues using YAML, it's not strictly non-breaking. So let's make the transition gradually and include it but don't make it the default yet.