### PR TITLE
Do not decode "+" to a space.

### DIFF
--- a/lib/Phile/Core/Router.php
+++ b/lib/Phile/Core/Router.php
@@ -52,7 +52,7 @@ class Router {
 		}
 		$url = ltrim($url, '/');
 
-		$url = urldecode($url);
+		$url = rawurldecode($url);
 
 		return $url;
 	}

--- a/tests/Phile/Core/RouterTest.php
+++ b/tests/Phile/Core/RouterTest.php
@@ -92,6 +92,14 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * test that + is not decoded to space
+	 */
+	public function testPlusNotSpace() {
+		$router = new Router(['REQUEST_URI' => '/foo+bar/foobar']);
+		$this->assertEquals('foo+bar/foobar', $router->getCurrentUrl());
+	}
+
+	/**
 	 * test that base-URL is removed
 	 */
 	public function testGetUrlRemoveUrlPath() {


### PR DESCRIPTION
As far as I know, + is only supposed to decode to a space in a query string, not in the path.  

I recently noticed some of my pages with 'c++' in the name were not working due to Phile decoding the plus as a space.  This fixes that and allows + to work in the URL path.