### PR TITLE
improve page ordering

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -32,7 +32,7 @@ Text files are marked up using [Markdown](http://daringfireball.net/projects/mar
 
 At the top of text files you can place a block comment and specify certain attributes of the page. For example:
 
-~~~ .markdown
+```markdown
 /*
 Title: Welcome
 Description: This description will go in the meta description tag
@@ -40,11 +40,11 @@ Author: Joe Bloggs
 Date: 2013/01/01
 Robots: noindex,nofollow
 */
-~~~
+```
 
 Phile also allows HTML style block comments:
 
-~~~ .html
+```html
 <!--
 Title: Welcome
 Description: This description will go in the meta description tag
@@ -52,7 +52,7 @@ Author: Joe Bloggs
 Date: 2013/01/01
 Robots: noindex,nofollow
 -->
-~~~
+```
 
 #### Custom Meta
 
@@ -60,7 +60,7 @@ You can actually create custom meta attributes by default in Phile. If you want 
 
 #### Custom Meta Ordering
 
-You can order pages by their custom meta attributes. Like creating an `Order` meta for each page, then you can use `$config['pages_order_by'] = "meta:order";` in your `config.php` file.
+You can order pages by their custom meta attributes. Like creating an `Order` meta for each page, then you can use `$config['pages_order'] = "meta.order:asc";` in your `config.php` file.
 
 ### Themes
 
@@ -90,13 +90,13 @@ All themes must include an `index.html` file to define the HTML structure of the
 
 Page listing example:
 
-~~~ .html
+```html
 <ul class="nav">
   {% for page in pages %}
     <li><a href="{{ page.url }}">{{ page.title }}</a></li>
   {% endfor %}
 </ul>
-~~~
+```
 
 ### Config
 

--- a/default_config.php
+++ b/default_config.php
@@ -32,9 +32,21 @@ $config['theme'] = 'default';
 $config['date_format'] = 'jS M Y';
 
 /**
- * page order
+ * Set page order
  *
- * Order pages by "title" (alpha) or "date"
+ * Format <type>.<attribute>:<order>
+ * type:
+ * - "page" page attribute
+ * - "meta" page meta attribute
+ * order:
+ * - "asc" (default) ascending order
+ * - "desc" descending order
+ *
+ * Orders are chainable to for sub-ordering.
+ *
+ * Examples:
+ * - "meta.title" sort by meta title ascending
+ * - "page.folder:asc meta.date:desc" sort by folder-name first and by date withing folders
  */
 $config['pages_order'] = 'meta.title:desc';
 

--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -112,14 +112,17 @@ class Page
                 // parse search	criteria
                 $terms = preg_split('/\s+/', $options['pages_order'], -1, PREG_SPLIT_NO_EMPTY);
                 foreach ($terms as $term) {
-                    $term = explode('.', $term);
-                    if (count($term) > 1) {
-                        $type = array_shift($term);
+                    $sub = explode('.', $term);
+                    if (count($sub) > 1) {
+                        $type = array_shift($sub);
                     } else {
                         $type = null;
                     }
-                    $term = explode(':', $term[0]);
-                    $sorting[] = array('type' => $type, 'key' => $term[0], 'order' => $term[1]);
+                    $sub = explode(':', $sub[0]);
+                    if (count($sub) === 1) {
+                        $sub[1] = 'asc';
+                    }
+                    $sorting[] = array('type' => $type, 'key' => $sub[0], 'order' => $sub[1], 'string' => $term);
                 }
 
                 // prepare search criteria for array_multisort
@@ -137,7 +140,11 @@ class Page
                         } elseif ($sort['type'] === 'meta') {
                             $value = $meta->get($key);
                         } else {
-                            continue 2; // ignore unhandled search term
+                            trigger_error(
+                                "Page order '{$sort['string']}' was ignored. Type '{$sort['type']}' not recognized.",
+                                E_USER_WARNING
+                            );
+                            continue 2;
                         }
                         $column[] = $value;
                     }

--- a/tests/Phile/Repository/PageTest.php
+++ b/tests/Phile/Repository/PageTest.php
@@ -81,15 +81,39 @@ class PageTest extends \PHPUnit_Framework_TestCase
     /**
      *
      */
-    public function testCanFindAllPagesOrderdByTitle()
+    public function testOrderingFindByMeta()
     {
-        // @TODO: maybe find a better way to check the correct order
-        $titles = ["Sub Page", "Sub Page Index", "Welcome"];
-        $pages = $this->pageRepository->findAll(
-            ['pages_order' => 'meta:title']
+        // setup
+        $titles = ['Sub Page', 'Sub Page Index', 'Welcome'];
+        $test = function ($titles, $order) {
+            $options = ['pages_order' => $order];
+            $pages = $this->pageRepository->findAll($options);
+            for ($i = 0; $i < count($pages); $i++) {
+                $this->assertEquals($pages[$i]->getTitle(), $titles[$i]);
+            }
+        };
+
+        // test ascending as default
+        $order = 'meta.title';
+        $test($titles, $order);
+
+        // test descending
+        $order = 'meta.title:desc';
+        $titles = array_reverse($titles);
+        $test($titles, $order);
+    }
+
+    /**
+     *
+     */
+    public function testOrderingInvalidSearchType()
+    {
+        $this->setExpectedException(
+            'PHPUnit_Framework_Error_Warning',
+            'Page order \'meta:title\' was ignored. Type \'\' not recognized.'
         );
-        for ($i = 0; $i < count($pages); $i++) {
-            $this->assertEquals($pages[$i]->getTitle(), $titles[$i]);
-        }
+        $this->pageRepository
+            ->findAll(['pages_order' => 'meta:title'])
+            ->toArray();
     }
 }


### PR DESCRIPTION
- fix and extend documentation #275
- default to "asc" if no sort order is provided
- trigger warning instead of failing silently if sort type isn't recognized
- fix and extend test cases