### PR TITLE
recognize '---' as meta data fence

### DIFF
--- a/plugins/phile/parserMeta/Classes/Parser/Meta.php
+++ b/plugins/phile/parserMeta/Classes/Parser/Meta.php
@@ -43,14 +43,19 @@ class Meta implements MetaInterface
     public function parse($rawData)
     {
         $rawData = trim($rawData);
+        $fences = $this->config['fences'];
 
-        $start = substr($rawData, 0, 4);
-        if ($start === '<!--') {
-            $stop = '-->';
-        } elseif (substr($start, 0, 2) === '/*') {
-            $start = '/*';
-            $stop = '*/';
-        } else {
+        $stop = null;
+        foreach ($fences as $fence) {
+            $start = $fence['open'];
+            $length = strlen($start);
+            if (substr($rawData, 0, $length) === $start) {
+                $stop = $fence['close'];
+                break;
+            }
+        }
+
+        if ($stop === null) {
             return [];
         }
 

--- a/plugins/phile/parserMeta/Classes/Parser/Meta.php
+++ b/plugins/phile/parserMeta/Classes/Parser/Meta.php
@@ -45,7 +45,7 @@ class Meta implements MetaInterface
         $rawData = trim($rawData);
         $fences = $this->config['fences'];
 
-        $stop = null;
+        $start = $stop = null;
         foreach ($fences as $fence) {
             $start = $fence['open'];
             $length = strlen($start);

--- a/plugins/phile/parserMeta/config.php
+++ b/plugins/phile/parserMeta/config.php
@@ -9,6 +9,7 @@ return [
     'fences' =>
         [
             'c' => ['open' => '/*', 'close' => '*/'],
-            'html' => ['open' => '<!--', 'close' => '-->']
+            'html' => ['open' => '<!--', 'close' => '-->'],
+            'yaml' => ['open' => '---', 'close' => '---']
         ]
 ];

--- a/plugins/phile/parserMeta/config.php
+++ b/plugins/phile/parserMeta/config.php
@@ -2,4 +2,13 @@
 /**
  * config file
  */
-return array();
+return [
+    /**
+     * open and close tokens for meta tags
+     */
+    'fences' =>
+        [
+            'c' => ['open' => '/*', 'close' => '*/'],
+            'html' => ['open' => '<!--', 'close' => '-->']
+        ]
+];

--- a/tests/Phile/Model/MetaTest.php
+++ b/tests/Phile/Model/MetaTest.php
@@ -43,6 +43,14 @@ Date: 2014-08-01
 ";
 
     /**
+     * @var string meta data in YAML front matter format
+     */
+    protected $metaTestData3 = "---
+Title: Welcome
+---
+";
+
+    /**
      *
      */
     public function testCanGetMetaProperty()
@@ -86,5 +94,11 @@ Date: 2014-08-01
             'Should become underscored',
             $meta->get('spaced_key')
         );
+    }
+
+    public function testYamlFrontMatterFormat()
+    {
+        $meta = new \Phile\Model\Meta($this->metaTestData3);
+        $this->assertEquals('Welcome', $meta['title']);
     }
 }


### PR DESCRIPTION
`---` is used by some markup parsers as meta-data fence (e.g. [Jekyll](http://jekyllrb.com/docs/frontmatter/)) and should be supported by Phile.

This PR replaces the existing hardcoded `<!--` and `/*` with a configurable plugin parameter and adds `---`.