### PR TITLE
[TASK] Updates phpFastCache from version 3 to 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "php": ">=5.6.0",
         "twig/twig": "^1.15.0",
         "michelf/php-markdown": ">=1.4",
-        "phpfastcache/phpfastcache": "~3.0",
+        "psr/simple-cache": "^1.0",
+        "phpfastcache/phpfastcache": "^6.0",
         "symfony/yaml": "^2.7",
         "phile-cms/plugin-installer-plugin": "^1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8fcedf77f95ec3118fd8381b87f39137",
+    "content-hash": "db0542522de719bcfa674b57c167ba0d",
     "packages": [
         {
             "name": "michelf/php-markdown",
@@ -102,26 +102,48 @@
         },
         {
             "name": "phpfastcache/phpfastcache",
-            "version": "3.1.1",
+            "version": "6.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPSocialNetwork/phpfastcache.git",
-                "reference": "53241bf437488c4bcfceccb054595d344cf343a3"
+                "reference": "606c29476bd21d907dcd535716d66b31aa999538"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPSocialNetwork/phpfastcache/zipball/53241bf437488c4bcfceccb054595d344cf343a3",
-                "reference": "53241bf437488c4bcfceccb054595d344cf343a3",
+                "url": "https://api.github.com/repos/PHPSocialNetwork/phpfastcache/zipball/606c29476bd21d907dcd535716d66b31aa999538",
+                "reference": "606c29476bd21d907dcd535716d66b31aa999538",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.1.0"
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^5.6 || ^7.0 || ^7.1 || ^7.2",
+                "psr/cache": "~1.0.0",
+                "psr/simple-cache": "~1.0.0"
+            },
+            "conflict": {
+                "doctrine/couchdb": "*"
+            },
+            "suggest": {
+                "ext-apc": "*",
+                "ext-intl": "*",
+                "ext-leveldb": "*",
+                "ext-memcache": "*",
+                "ext-memcached": "*",
+                "ext-redis": "*",
+                "ext-sqlite": "*",
+                "ext-wincache": "*",
+                "ext-xcache": "*",
+                "mongodb/mongodb": "^1.1",
+                "phpfastcache/couchdb": "~1.0.0",
+                "phpfastcache/phpssdb": "~1.0.0",
+                "predis/predis": "~1.1.0"
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "phpfastcache.php"
-                ]
+                "psr-4": {
+                    "phpFastCache\\": "src/phpFastCache/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -133,28 +155,140 @@
                     "email": "khoaofgod@gmail.com",
                     "homepage": "http://www.phpfastcache.com",
                     "role": "Developer"
+                },
+                {
+                    "name": "Georges.L",
+                    "email": "contact@geolim4.com",
+                    "homepage": "https://github.com/Geolim4",
+                    "role": "Developer"
                 }
             ],
-            "description": "PHP Cache Class - Supported Redis, Cookie, Predis, APC, MemCached, WinCache, Files, PDO, Reduce mySQL Call by Caching",
+            "description": "PHP Cache Class - Reduce your database call using cache system. PhpFastCache handles a lot of drivers such as Apc(u), Cassandra, CouchBase, Couchdb, Mongodb, Files, (P)redis, Leveldb, Memcache(d), Ssdb, Sqlite, Wincache, Xcache, Zend Data Cache.",
             "homepage": "http://www.phpfastcache.com",
             "keywords": [
-                "APC Cache",
+                "LevelDb",
                 "apc",
+                "apcu",
                 "cache",
                 "cache class",
                 "caching",
+                "cassandra",
                 "cookie",
+                "couchbase",
+                "couchdb",
                 "files cache",
                 "memcache",
                 "memcached",
+                "mongodb",
                 "mysql cache",
                 "pdo cache",
                 "php cache",
                 "predis",
                 "redis",
-                "wincache"
+                "ssdb",
+                "wincache",
+                "xcache",
+                "zend",
+                "zend data cache",
+                "zend disk cache",
+                "zend memory cache",
+                "zend server"
             ],
-            "time": "2016-02-03T22:06:21+00:00"
+            "time": "2017-12-15T22:11:25+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "753fa598e8f3b9966c886fe13f370baa45ef0e24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/753fa598e8f3b9966c886fe13f370baa45ef0e24",
+                "reference": "753fa598e8f3b9966c886fe13f370baa45ef0e24",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-01-02T13:31:39+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2786,16 +2920,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.7.0",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "9b355654ea99460397b89c132b5c1087b6bf4473"
+                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9b355654ea99460397b89c132b5c1087b6bf4473",
-                "reference": "9b355654ea99460397b89c132b5c1087b6bf4473",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/d15f59a67ff805a44c50ea0516d2341740f81a38",
+                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38",
                 "shasum": ""
             },
             "require": {
@@ -2831,7 +2965,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2018-01-03T12:13:57+00:00"
+            "time": "2018-01-24T12:46:19+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/lib/Phile/ServiceLocator/CacheInterface.php
+++ b/lib/Phile/ServiceLocator/CacheInterface.php
@@ -37,7 +37,7 @@ interface CacheInterface
      * @param $key
      * @param $value
      * @param int   $time
-     * @param array $options
+     * @param array $options deprecated
      *
      * @return mixed
      */
@@ -47,7 +47,7 @@ interface CacheInterface
      * delete the entry by given key
      *
      * @param $key
-     * @param array $options
+     * @param array $options deprecated
      *
      * @return mixed
      */

--- a/plugins/phile/phpFastCache/Classes/PhileToPsr16CacheAdapter.php
+++ b/plugins/phile/phpFastCache/Classes/PhileToPsr16CacheAdapter.php
@@ -1,18 +1,21 @@
 <?php
 /**
- * The PhpFastCache implemenation class
+ * Adapter to use PSR-16 compatible cache class with Phile
  */
+
 namespace Phile\Plugin\Phile\PhpFastCache;
+
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * Class PhpFastCache
  *
- * @author  Frank Nägler
+ * @author  PhileCMS
  * @link    https://philecms.com
  * @license http://opensource.org/licenses/MIT
  * @package Phile\Plugin\Phile\PhpFastCache
  */
-class PhpFastCache implements \Phile\ServiceLocator\CacheInterface
+class PhileToPsr16CacheAdapter implements \Phile\ServiceLocator\CacheInterface
 {
     /**
      * @var \BasePhpFastCache the cache engine
@@ -24,7 +27,7 @@ class PhpFastCache implements \Phile\ServiceLocator\CacheInterface
      *
      * @param \BasePhpFastCache $cacheEngine
      */
-    public function __construct(\BasePhpFastCache $cacheEngine)
+    public function __construct(CacheInterface $cacheEngine)
     {
         $this->cacheEngine = $cacheEngine;
     }
@@ -38,7 +41,7 @@ class PhpFastCache implements \Phile\ServiceLocator\CacheInterface
      */
     public function has($key)
     {
-        return ($this->cacheEngine->get($key) !== null);
+        return $this->cacheEngine->has($key);
     }
 
     /**
@@ -59,26 +62,34 @@ class PhpFastCache implements \Phile\ServiceLocator\CacheInterface
      * @param string $key
      * @param string $value
      * @param int    $time
-     * @param array  $options
+     * @param array  $options deprecated
      *
      * @return mixed|void
      */
     public function set($key, $value, $time = 300, array $options = array())
     {
-        $this->cacheEngine->set($key, $value, $time, $options);
+        if (!empty($options)) {
+            // not longer supported by phpFastCache
+            trigger_error('Argument $options is deprecated and ignored.', E_USER_WARNING);
+        }
+        $this->cacheEngine->set($key, $value, $time);
     }
 
     /**
      * method to delete cache entry
      *
      * @param string $key
-     * @param array  $options
+     * @param array  $options deprecated
      *
      * @return mixed|void
      */
     public function delete($key, array $options = array())
     {
-        $this->cacheEngine->delete($key, $options);
+        if (!empty($options)) {
+            // not longer supported by phpFastCache
+            trigger_error('Argument $options is deprecated and ignored.', E_USER_WARNING);
+        }
+        $this->cacheEngine->delete($key);
     }
 
     /**
@@ -86,6 +97,6 @@ class PhpFastCache implements \Phile\ServiceLocator\CacheInterface
      */
     public function clean()
     {
-        $this->cacheEngine->clean();
+        $this->cacheEngine->clear();
     }
 }

--- a/plugins/phile/phpFastCache/Classes/Plugin.php
+++ b/plugins/phile/phpFastCache/Classes/Plugin.php
@@ -26,14 +26,17 @@ class Plugin extends AbstractPlugin
      */
     public function onPluginsLoaded()
     {
-        // phpFastCache not working in CLI mode...
         if (PHILE_CLI_MODE) {
+            // phpFastCache not working in CLI mode...
             return;
         }
-        unset($this->settings['active']);
-        $config = $this->settings + \phpFastCache::$config;
+
         $storage = $this->settings['storage'];
-        $cache = phpFastCache($storage, $config);
-        ServiceLocator::registerService('Phile_Cache', new PhpFastCache($cache));
+        $config = $this->settings;
+        unset($config['active'], $config['storage']);
+        $psr16Cache = new \phpFastCache\Helper\Psr16Adapter($storage, $config);
+
+        $phileCache = new PhileToPsr16CacheAdapter($psr16Cache);
+        ServiceLocator::registerService('Phile_Cache', $phileCache);
     }
 }

--- a/plugins/phile/phpFastCache/config.php
+++ b/plugins/phile/phpFastCache/config.php
@@ -10,7 +10,7 @@ $config = [
      *
      * auto, files, sqlite, auto, apc, wincache, xcache, memcache, memcached,
      */
-    'storage' => 'auto',
+    'storage' => 'files',
 
     /**
      * Default Path for File Cache
@@ -42,15 +42,18 @@ $config = [
 //	"htaccess"    => true,
 
     /*
-	 * Default Memcache Server for all $cache = phpFastCache("memcache");
-	 */
+     * Default Memcache Server for Memcache
+     */
     /*
-	"memcache"        =>  array(
-		array("127.0.0.1",11211,1),
-		//  array("new.host.ip",11211,1),
-	),
-	*/
-
+    'servers' => [
+        [
+            'host' =>'127.0.0.1',
+            'port' => 11211,
+              // 'sasl_user' => false, // optional
+              // 'sasl_password' => false // optional
+        ]
+    ],
+     */
 ];
 
 return $config;


### PR DESCRIPTION
This updates phpFastCache from version 3 to 6 (last version working with PHP 5.6).

Alas the phpFastCache-API is not completely compatible anymore: the `$option` argument in `CacheInterface::set($key, $value, $time, $options)` and `CacheInterface::delete($key, $options)` isn't available and easily implemented.

So this commit marks `$option` as deprecated, ignores it and throws a warning if used. I think this change is OK, I never saw someone using it.

On the other hand the Phile cache API nearly matches the [PSR-16](http://www.php-fig.org/psr/psr-16/) specs now. So talking to phpFastCache can utilize their PSR-16 API and is essentially a lightweight adapter to PSR-16.

With that Phile may easily drop its own cache interface and implementation to just embrace the PSR-16 interface in the future. 

@PhileCMS/Phile please review this pull request
