### PR TITLE
fixes #298 - inserts version string to composer on build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -110,7 +110,7 @@
     </if>
 
     <echo msg="Insert version string into composer.json"/>
-    <exec command="cat lib/Phile/Bootstrap.php | grep 'PHILE_VERSION' | grep -Eio &quot;(([0-9][^'\&quot;]?){1,})&quot;"
+    <exec command="grep 'PHILE_VERSION' lib/Phile/Bootstrap.php | grep -Eio &quot;(([0-9][^'\&quot;]?){1,})&quot;"
           outputProperty="phile.version"/>
     <exec command="awk 'NR==3{print &quot;    \&quot;version\&quot;: \&quot;${phile.version}\&quot;,&quot;}1' ${dirs.git}/composer.json &gt; ${dirs.git}/tmp.json &amp;&amp; mv ${dirs.git}/tmp.json ${dirs.git}/composer.json"/>
     <exec command="composer update --no-lock" dir="${dirs.git}"/>

--- a/build.xml
+++ b/build.xml
@@ -109,6 +109,12 @@
       </then>
     </if>
 
+    <echo msg="Insert version string into composer.json"/>
+    <exec command="cat lib/Phile/Bootstrap.php | grep 'PHILE_VERSION' | grep -Eio &quot;(([0-9][^'\&quot;]?){1,})&quot;"
+          outputProperty="phile.version"/>
+    <exec command="awk 'NR==3{print &quot;    \&quot;version\&quot;: \&quot;${phile.version}\&quot;,&quot;}1' ${dirs.git}/composer.json &gt; ${dirs.git}/tmp.json &amp;&amp; mv ${dirs.git}/tmp.json ${dirs.git}/composer.json"/>
+    <exec command="composer update --no-lock" dir="${dirs.git}"/>
+
     <echo msg="Install composer packages"/>
     <exec command="composer install --optimize-autoloader --no-dev"
           dir="${dirs.git}"/>


### PR DESCRIPTION
Non-composer/download installation needs a hint which version of Phile is running.