### PR TITLE
[FEATURE] Couple Repository\Page to Model\Page

### DIFF
--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -7,8 +7,8 @@ namespace Phile\Model;
 use Phile\Core\Router;
 use Phile\Core\Event;
 use Phile\Core\Registry;
-use Phile\Core\Repository;
 use Phile\Core\ServiceLocator;
+use Phile\Repository\Page as Repository;
 
 /**
  * the Model class for a page
@@ -51,16 +51,6 @@ class Page
     protected $pageId;
 
     /**
-     * @var \Phile\Model\Page the previous page if one exist
-     */
-    protected $previousPage;
-
-    /**
-     * @var \Phile\Model\Page the next page if one exist
-     */
-    protected $nextPage;
-
-    /**
      * @var string The content folder, as passed to the class constructor when initiating the object.
      */
     protected $contentFolder;
@@ -69,6 +59,9 @@ class Page
      * @var string content extension
      */
     protected $contentExtension;
+
+    /** @var Repository */
+    protected $repository;
 
     /**
      * the constructor
@@ -190,6 +183,31 @@ class Page
     }
 
     /**
+     * Sets repository this page was retrieved by/belongs to
+     *
+     * @param Repository $repository
+     * @return $this
+     */
+    public function setRepository(Repository $repository)
+    {
+        $this->repository = $repository;
+        return $this;
+    }
+
+    /**
+     * Gets repository this page belongs to
+     *
+     * @return Repository
+     */
+    public function getRepository()
+    {
+        if (!$this->repository) {
+            $this->repository = new Repository();
+        }
+        return $this->repository;
+    }
+
+    /**
      * get the title of page from meta information
      *
      * @return string|null
@@ -268,8 +286,7 @@ class Page
      */
     public function getPreviousPage()
     {
-        $pageRepository = new \Phile\Repository\Page();
-        return $pageRepository->getPageOffset($this, -1);
+        return $this->getRepository()->getPageOffset($this, -1);
     }
 
     /**
@@ -279,7 +296,6 @@ class Page
      */
     public function getNextPage()
     {
-        $pageRepository = new \Phile\Repository\Page();
-        return $pageRepository->getPageOffset($this, 1);
+        return $this->getRepository()->getPageOffset($this, 1);
     }
 }

--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -189,7 +189,7 @@ class Page
      * @param $filePath
      * @param string   $folder
      *
-     * @return mixed|\Phile\Model\Page
+     * @return \Phile\Model\Page
      */
     protected function getPage($filePath, $folder = null)
     {
@@ -209,6 +209,7 @@ class Page
         } else {
             $page = new \Phile\Model\Page($filePath, $folder);
         }
+        $page->setRepository($this);
         $this->storage[$key] = $page;
 
         return $page;

--- a/plugins/phile/templateTwig/Classes/Template/Twig.php
+++ b/plugins/phile/templateTwig/Classes/Template/Twig.php
@@ -158,7 +158,6 @@ class Twig implements TemplateInterface
      */
     protected function getTemplateVars()
     {
-        $repository = new Repository($this->settings);
         $defaults = [
         'content' => $this->page->getContent(),
         'meta' => $this->page->getMeta(),
@@ -168,7 +167,7 @@ class Twig implements TemplateInterface
         'config' => $this->settings,
         'content_dir' => $this->settings['content_dir'],
         'content_url' => $this->settings['base_url'] . '/' . basename($this->settings['content_dir']),
-        'pages' => $repository->findAll(),
+        'pages' => $this->page->getRepository()->findAll(),
         'site_title' => $this->settings['site_title'],
         'theme_dir' => THEMES_DIR . $this->settings['theme'],
         'theme_url' => $this->settings['base_url'] . '/' . basename(THEMES_DIR) . '/' . $this->settings['theme'],

--- a/tests/Phile/Model/PageTest.php
+++ b/tests/Phile/Model/PageTest.php
@@ -2,6 +2,7 @@
 
 namespace PhileTest\Model;
 
+use Phile\Repository\Page as Repository;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,7 +26,7 @@ class PageTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->pageRepository = new \Phile\Repository\Page();
+        $this->pageRepository = new Repository();
     }
 
     /**
@@ -136,5 +137,22 @@ class PageTest extends TestCase
         $page = $this->pageRepository->findByPath('index');
         $this->assertInstanceOf('\Phile\Model\Page', $page->getNextPage());
         $this->assertEquals('Sub Page Index', $page->getNextPage()->getTitle());
+    }
+
+    public function testRepositoryGet()
+    {
+        $page = $this->pageRepository->findByPath('index');
+        $this->assertInstanceOf(Repository::class, $page->getRepository());
+    }
+
+    public function testRepositorySet()
+    {
+        $page = $this->pageRepository->findByPath('index');
+
+        $repository = new Repository;
+        $this->assertNotSame($repository, $page->getRepository());
+
+        $page->setRepository($repository);
+        $this->assertSame($repository, $page->getRepository());
     }
 }


### PR DESCRIPTION
Both depend on each other throughout the app. Repository retrieves Model. Model accesses Repository. Then other parts of the app need a Repository to create context for a Model again.

Instead of always creating new Repository instances it would be much more convenient and performance friendly to just pass the Repository a Model was created by around with the Model. 

