### PR TITLE
Restore backwards compatibility in cache keys lost in 1.8 #306

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
     <testsuites>
         <testsuite name="core">
             <directory>tests/</directory>
+            <directory>plugins/phile/phpFastCache/tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/plugins/phile/phpFastCache/Classes/PhileToPsr16CacheAdapter.php
+++ b/plugins/phile/phpFastCache/Classes/PhileToPsr16CacheAdapter.php
@@ -117,18 +117,12 @@ class PhileToPsr16CacheAdapter implements \Phile\ServiceLocator\CacheInterface
      */
     protected function slug($key)
     {
-        $replacer = function ($character) {
-            $key = array_search($character[0], self::SLUG);
-            $replacement = self::SLUG_PREFIX . $key;
-            return $replacement;
-        };
-        $search = array_map(
-            function ($value) {
-                return preg_quote($value);
+        $replacementTokens = array_map(
+            function ($key) {
+                return self::SLUG_PREFIX . $key;
             },
-            self::SLUG
+            array_keys(self::SLUG)
         );
-        $search = '!' . implode('|', $search) . '!';
-        return preg_replace_callback($search, $replacer, $key);
+        return str_replace(self::SLUG, $replacementTokens, $key);
     }
 }

--- a/plugins/phile/phpFastCache/Classes/PhileToPsr16CacheAdapter.php
+++ b/plugins/phile/phpFastCache/Classes/PhileToPsr16CacheAdapter.php
@@ -17,6 +17,9 @@ use Psr\SimpleCache\CacheInterface;
  */
 class PhileToPsr16CacheAdapter implements \Phile\ServiceLocator\CacheInterface
 {
+    /** @var string slug */
+    const SLUG = '-phile.phpFastCache.slug-';
+    
     /**
      * @var \BasePhpFastCache the cache engine
      */
@@ -41,6 +44,7 @@ class PhileToPsr16CacheAdapter implements \Phile\ServiceLocator\CacheInterface
      */
     public function has($key)
     {
+        $key = $this->slug($key);
         return $this->cacheEngine->has($key);
     }
 
@@ -53,6 +57,7 @@ class PhileToPsr16CacheAdapter implements \Phile\ServiceLocator\CacheInterface
      */
     public function get($key)
     {
+        $key = $this->slug($key);
         return $this->cacheEngine->get($key);
     }
 
@@ -72,6 +77,7 @@ class PhileToPsr16CacheAdapter implements \Phile\ServiceLocator\CacheInterface
             // not longer supported by phpFastCache
             trigger_error('Argument $options is deprecated and ignored.', E_USER_WARNING);
         }
+        $key = $this->slug($key);
         $this->cacheEngine->set($key, $value, $time);
     }
 
@@ -89,6 +95,7 @@ class PhileToPsr16CacheAdapter implements \Phile\ServiceLocator\CacheInterface
             // not longer supported by phpFastCache
             trigger_error('Argument $options is deprecated and ignored.', E_USER_WARNING);
         }
+        $key = $this->slug($key);
         $this->cacheEngine->delete($key);
     }
 
@@ -98,5 +105,17 @@ class PhileToPsr16CacheAdapter implements \Phile\ServiceLocator\CacheInterface
     public function clean()
     {
         $this->cacheEngine->clear();
+    }
+
+    /**
+     * replaces chars forbidden in PSR-16 cache-keys
+     *
+     * @param string $key key to slug
+     * @return string $key slugged key
+     */
+    protected function slug($key)
+    {
+        $psr16Forbidden = ['{', '}' , '(', ')', '/' , '\\' , '@', ':'];
+        return str_replace($psr16Forbidden, self::SLUG, $key);
     }
 }

--- a/plugins/phile/phpFastCache/Classes/PhileToPsr16CacheAdapter.php
+++ b/plugins/phile/phpFastCache/Classes/PhileToPsr16CacheAdapter.php
@@ -18,8 +18,10 @@ use Psr\SimpleCache\CacheInterface;
 class PhileToPsr16CacheAdapter implements \Phile\ServiceLocator\CacheInterface
 {
     /** @var string slug */
-    const SLUG = '-phile.phpFastCache.slug-';
+    const SLUG_PREFIX = '-phile.phpFastCache.slug-';
     
+    const SLUG = ['{', '}' , '(', ')', '/' , '\\' , '@', ':'];
+
     /**
      * @var \BasePhpFastCache the cache engine
      */
@@ -115,7 +117,18 @@ class PhileToPsr16CacheAdapter implements \Phile\ServiceLocator\CacheInterface
      */
     protected function slug($key)
     {
-        $psr16Forbidden = ['{', '}' , '(', ')', '/' , '\\' , '@', ':'];
-        return str_replace($psr16Forbidden, self::SLUG, $key);
+        $replacer = function ($character) {
+            $key = array_search($character[0], self::SLUG);
+            $replacement = self::SLUG_PREFIX . $key;
+            return $replacement;
+        };
+        $search = array_map(
+            function ($value) {
+                return preg_quote($value);
+            },
+            self::SLUG
+        );
+        $search = '!' . implode('|', $search) . '!';
+        return preg_replace_callback($search, $replacer, $key);
     }
 }

--- a/plugins/phile/phpFastCache/tests/PhileToPsr16CacheAdapterTest.php
+++ b/plugins/phile/phpFastCache/tests/PhileToPsr16CacheAdapterTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Phile\Plugin\Phile\PhpFastCache\Tests;
+
+use Phile\Plugin\Phile\PhpFastCache\PhileToPsr16CacheAdapter;
+use phpFastCache\Helper\Psr16Adapter;
+use PHPUnit\Framework\TestCase;
+
+class PhileToPsr16CacheAdapterTest extends TestCase
+{
+    public function testSlug()
+    {
+        $psr16Cache = new Psr16Adapter('memstatic');
+        $adapter = new PhileToPsr16CacheAdapter($psr16Cache);
+
+        $adapter->set("{}()\/:@", 'foo');
+        $this->assertSame('foo', $adapter->get("{}()\/:@"));
+
+        $adapter->set('}foo', 'bar');
+        $adapter->set('{foo', 'baz');
+        $this->assertSame('bar', $adapter->get('}foo'));
+    }
+}


### PR DESCRIPTION
The characters `{}()/\@:` are not allowed as cache keys for the build-in cache-engine in 1.8 anymore.

This PR slugs those characters to restore backwards-compatibility.