### PR TITLE
adds Phile version string to composer.json

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -111,12 +111,6 @@
       </then>
     </if>
 
-    <echo msg="Insert version string into composer.json"/>
-    <exec command="grep 'PHILE_VERSION' lib/Phile/Bootstrap.php | grep -Eio &quot;(([0-9][^'\&quot;]?){1,})&quot;"
-          outputProperty="phile.version"/>
-    <exec command="awk 'NR==3{print &quot;    \&quot;version\&quot;: \&quot;${phile.version}\&quot;,&quot;}1' ${dirs.git}/composer.json &gt; ${dirs.git}/tmp.json &amp;&amp; mv ${dirs.git}/tmp.json ${dirs.git}/composer.json"/>
-    <exec command="composer update --no-lock" dir="${dirs.git}"/>
-
     <echo msg="Install composer packages"/>
     <exec command="composer install --optimize-autoloader --no-dev"
           dir="${dirs.git}"/>

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "phile-cms/phile",
+    "version": "1.8.0",
     "type": "project",
     "description": "A file-based CMS with a swappable parser, template engine, cache and storage services, error handler, and meta parser.",
     "keywords": ["cms", "markdown", "flat", "file", "twig", "plugins"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7e23341e1dc2ec3386a622b35c1747b",
+    "content-hash": "a9390bd21a264b559a56a3aec3438836",
     "packages": [
         {
             "name": "http-interop/http-factory",


### PR DESCRIPTION
To have the Phile version available in the release package, in a git checkout, in a create-project installation, … it is just easier to update it manually on release.

Otherwise we need more complicated scripts fixing it for the release package or on create-project.

This will resolve itself if Phile is ever split in an app-skeleton and an auto-versioned core package.

closes #319