### PR TITLE
[FEATURE] make 404 page configurable

### DIFF
--- a/config/defaults.php
+++ b/config/defaults.php
@@ -79,6 +79,11 @@ $config['content_dir'] = ROOT_DIR . 'content' . DS;
 $config['content_ext'] = '.md';
 
 /**
+ * Not found page.
+ */
+$config['not_found_page'] = '404';
+
+/**
  * include core plugins
  */
 $config['plugins'] = [

--- a/lib/Phile/Phile.php
+++ b/lib/Phile/Phile.php
@@ -125,7 +125,7 @@ class Phile implements MiddlewareInterface
         $response = (new Response)->createHtmlResponse($html)
             ->withHeader('Content-Type', 'text/html; charset=' . $charset);
 
-        if ($page->getPageId() == '404') {
+        if ($page->getPageId() == $this->config->get('not_found_page')) {
             $response = $response->withStatus(404) ;
         }
 
@@ -157,7 +157,7 @@ class Phile implements MiddlewareInterface
         }
 
         if (!$found) {
-            $page = $repository->findByPath('404');
+            $page = $repository->findByPath($this->config->get('not_found_page'));
             $this->eventBus->trigger('after_404');
         }
 

--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -99,8 +99,9 @@ class Page
                 // ignore files with a leading '.' in its filename
                 $files = Utility::getFiles($folder, '\Phile\FilterIterator\ContentFileFilterIterator');
                 $pages = array();
+                $notFoundPage = $this->settings['not_found_page'] . $this->settings['content_ext'];
                 foreach ($files as $file) {
-                    if (str_replace($folder, '', $file) == '404' . $this->settings['content_ext']) {
+                    if (str_replace($folder, '', $file) == $notFoundPage) {
                         // jump to next page if file is the 404 page
                         continue;
                     }

--- a/tests/Phile/Model/PageTest.php
+++ b/tests/Phile/Model/PageTest.php
@@ -77,10 +77,6 @@ class PageTest extends TestCase
         $result = $this->pageRepository->findByPath('index')->getUrl();
         $this->assertEquals('', $result);
 
-        // root page
-        $result = $this->pageRepository->findByPath('404')->getUrl();
-        $this->assertEquals('404', $result);
-
         // sub index
         $result = $this->pageRepository->findByPath('sub/')->getUrl();
         $this->assertEquals('sub/', $result);


### PR DESCRIPTION
Removed test offers no new insight on Model\Page::getUrl(). General 404
testing is done better by PhileTest::testPageNotFound().

closes #318