### PR TITLE
[BUG] fixes broken three dash '---' YAML front matter meta format

### DIFF
--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -176,18 +176,20 @@ class Page
     protected function parseRawData()
     {
         $this->meta = new Meta($this->rawData);
-        // Remove only the optional, leading meta-block comment
         $rawData = trim($this->rawData);
-        if (strncmp('<!--', $rawData, 4) === 0) {
-            // leading meta-block comment uses the <!-- --> style
-            $this->content = substr($rawData, max(4, strpos($rawData, '-->') + 3));
-        } elseif (strncmp('/*', $rawData, 2) === 0) {
-            // leading meta-block comment uses the /* */ style
-            $this->content = substr($rawData, strpos($rawData, '*/') + 2);
-        } else {
-            // no leading meta-block comment
-            $this->content = $rawData;
+        $fences = [
+            'c' => ['open' => '/*', 'close' => '*/'],
+            'html' => ['open' => '<!--', 'close' => '-->'],
+            'yaml' => ['open' => '---', 'close' => '---']
+        ];
+        $content = '';
+        foreach ($fences as $fence) {
+            if (strncmp($fence['open'], $rawData, strlen($fence['open'])) === 0) {
+                $sub = substr($rawData, strlen($fence['open']));
+                list($meta, $content) = explode($fence['close'], $sub, 2);
+            }
         }
+        $this->content = $content ?: $rawData;
     }
 
     /**

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -187,6 +187,7 @@ class Page
             if (strncmp($fence['open'], $rawData, strlen($fence['open'])) === 0) {
                 $sub = substr($rawData, strlen($fence['open']));
                 list(, $content) = explode($fence['close'], $sub, 2);
+                break;
             }
         }
         $this->content = $content ?: $rawData;

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -186,7 +186,7 @@ class Page
         foreach ($fences as $fence) {
             if (strncmp($fence['open'], $rawData, strlen($fence['open'])) === 0) {
                 $sub = substr($rawData, strlen($fence['open']));
-                list($meta, $content) = explode($fence['close'], $sub, 2);
+                list(, $content) = explode($fence['close'], $sub, 2);
             }
         }
         $this->content = $content ?: $rawData;

--- a/lib/Phile/Test/TestCase.php
+++ b/lib/Phile/Test/TestCase.php
@@ -36,6 +36,7 @@ abstract class TestCase extends PHPUnitTestCase
         if (!$config->has('encryptionKey')) {
             $config->set('encryptionKey', 'testing');
         }
+        $testConfig = $config->toArray();
 
         //# setup container
         Utility::load($config->get('config_dir') . '/container.php');
@@ -45,13 +46,12 @@ abstract class TestCase extends PHPUnitTestCase
             $container->set('Phile_EventBus', $event);
         }
 
-        $container->set('Phile_Config', $config);
-
         //# setup bootstrap
         $core = $container->get('Phile_App');
-        $core->addBootstrap(function ($eventBus, $config) {
+        $core->addBootstrap(function ($eventBus, $config) use ($testConfig) {
             $configDir = $config->get('config_dir');
             Bootstrap::loadConfiguration($configDir . 'defaults.php', $config);
+            $config->merge($testConfig);
 
             defined('CONTENT_DIR') || define('CONTENT_DIR', $config->get('content_dir'));
             defined('CONTENT_EXT') || define('CONTENT_EXT', $config->get('content_ext'));

--- a/plugins/phile/parserMeta/Classes/Parser/Meta.php
+++ b/plugins/phile/parserMeta/Classes/Parser/Meta.php
@@ -59,7 +59,7 @@ class Meta implements MetaInterface
             return [];
         }
 
-        $meta = trim(substr($rawData, strlen($start), strpos($rawData, $stop) - (strlen($stop) + 1)));
+        $meta = trim(substr($rawData, strlen($start), strpos($rawData, $stop, strlen($start)) - (strlen($stop) + 1)));
         if (strtolower($this->config['format']) === 'yaml') {
             $meta = Yaml::parse($meta);
         } else {

--- a/plugins/phile/parserMeta/tests/MetaTest.php
+++ b/plugins/phile/parserMeta/tests/MetaTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phile\Plugin\Phile\ParserMeta\Tests;
+
+use Phile\Plugin\Phile\ParserMeta\Parser\Meta;
+use Phile\Test\TestCase;
+
+class MetaTest extends TestCase
+{
+    public function testYamlWithYamlFrontMatter()
+    {
+        $this->createPhileCore()->bootstrap();
+
+        $raw = <<<EOF
+---
+Title: foo 
+Tags: [bar, baz]
+---
+
+Page Content
+EOF;
+
+        $parser = new Meta([
+            'fences' => ['yaml' => ['open' => '---', 'close' => '---']],
+            'format' => 'YAML'
+        ]);
+        $meta = $parser->parse($raw);
+        $this->assertSame('foo', $meta['title']);
+        $this->assertSame(['bar', 'baz'], $meta['tags']);
+    }
+}

--- a/tests/Phile/Model/MetaTest.php
+++ b/tests/Phile/Model/MetaTest.php
@@ -57,6 +57,7 @@ Date: 2014-08-01
     protected $metaTestData3 = "---
 Title: Welcome
 ---
+Content
 ";
 
     /**


### PR DESCRIPTION
Using YAML for metadata parsing together with `---` fence is broken:

```
---
title: foo
---
Content
```

