### PR TITLE
Improve testing to detect plugin breakage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,20 @@ language: php
 php:
 - 5.6
 - 7.0
-- 7.1
 
 env:
   global:
-    - PHPCS=0
+    - PHPCS=0 PLUGINS=0
 
 matrix:
   include:
+    - php: 7.1
+      env: PLUGINS=1
     - php: 7.2 
       env: PHPCS=1
 
 # Notifications
 notifications:
-  flowdock:
-    secure: QOArjMZ42xRjGPbqQwGm8xpaEGOe2M1Z8OB58zAnHRcxhfhmewiM/F73D6kVkDIUWe7PbaG9z3WZt+x0I0wu7wXdzjTq1lCA+e0B8xZFNxHtSzrbBm6frVbvDS9/j45HXQPxFhb98aJm/3KwegqPKQd/2jXy1DqNlwlrgIU81Ok=
-  email:
-    secure: OhUqB3QHtfaKiAtKE6WXOr/SChfG1r6tqNltrI90srxrtHAdMgfj5Nw6gVQaYibE6dxT65fomLbhNbZgfvdcQBGGLQgo27S9acVIsamfz4gvIP/TxNl+fv9aSEqnEn9t+aAlhGMW/K0W0vxWSzJ/J7DFB8J4R4OoJmbFdFQRPT4=
   webhooks:
     urls:
       # Gitter.im channel hook
@@ -34,13 +31,19 @@ notifications:
     on_failure: always
 
 # Scripts
-before_script:
-  # workaround for session dir not accessible in HHVM
-  - sh -c "if [ '$HHVM' = '1' ]; then echo 'session.gc_probability = 0' >> /etc/hhvm/php.ini; fi"
+install:
   - composer selfupdate --quiet
-  - composer install -n --prefer-source --no-dev
+  - |
+    if [ "$PHPCS" = "1" ] || [ "$PLUGINS" = "1" ]; then
+        composer install --prefer-dist --no-interaction
+    else
+        composer install --no-dev --no-interaction
+    fi
+  - |
+    if [ "$PLUGINS" = "1" ]; then
+        lib/vendor/bin/phing phile-plugins-install 
+    fi
 
-  - sh -c "if [ '$PHPCS' = '1' ]; then composer install --prefer-dist --no-interaction; fi"
 script:
 - |
   echo;

--- a/build.xml
+++ b/build.xml
@@ -196,12 +196,12 @@
 
     <target name="phile-plugins-install">
         <echo msg="Installing plug-ins…"/>
-        <exec command="composer require ${phile.plugins}" logoutput="true" />
+        <exec command="composer require ${phile.plugins}" checkreturn="true" logoutput="true" />
     </target>
 
     <target name="phile-plugins-uninstall">
         <echo msg="Uninstalling plug-ins…"/>
-        <exec command="composer remove ${phile.plugins}" logoutput="true" />
+        <exec command="composer remove ${phile.plugins}" checkreturn="true" logoutput="true" />
     </target>
 
 

--- a/build.xml
+++ b/build.xml
@@ -11,9 +11,10 @@
     <echo msg="1) build distribution zip"/>
     <echo msg="2) build phpdoc"/>
     <echo msg="3) run test suite"/>
+    <echo msg="4) Install additional 1st party plugins"/>
     <echo msg="x) exit"/>
 
-    <input message="Choose" propertyName="choice" validArgs="1,2,3,x"/>
+    <input message="Choose" propertyName="choice" validArgs="1,2,3,4,x"/>
 
     <if>
       <equals arg1="${choice}" arg2="1"/>
@@ -32,6 +33,13 @@
         <equals arg1="${choice}" arg2="3"/>
         <then>
           <phingcall target="tests"/>
+        </then>
+      </elseif>
+
+      <elseif>
+        <equals arg1="${choice}" arg2="4"/>
+        <then>
+          <phingcall target="phile-plugins"/>
         </then>
       </elseif>
 
@@ -150,5 +158,52 @@
               value="lib/vendor/bin/phpcs --standard=PSR2 -p --extensions=php --ignore=lib/vendor/ lib/ plugins/phile/ ."/>
     <exec command="${tests.formatting}" logoutput="true"/>
   </target>
+
+    <!-- ## Install plugins ## -->
+    <target name="phile-plugins">
+        <echo msg="Optional first party plug-ins:"/>
+        <echo msg="1) install"/>
+        <echo msg="2) uninstall"/>
+        <echo msg="x) exit"/>
+
+        <input message="Choose" propertyName="choice" validArgs="1,2,x"/>
+
+        <if>
+          <equals arg1="${choice}" arg2="1"/>
+          <then>
+            <phingcall target="phile-plugins-install"/>
+          </then>
+
+          <elseif>
+            <equals arg1="${choice}" arg2="2"/>
+            <then>
+              <phingcall target="phile-plugins-uninstall"/>
+            </then>
+          </elseif>
+
+          <elseif>
+            <equals arg1="${choice}" arg2="x"/>
+            <then>
+              <php expression="exit();"/>
+            </then>
+          </elseif>
+        </if>
+    </target>
+
+    <property name="phile.plugins" value="
+                phile/rss-feed
+            "/>
+
+    <target name="phile-plugins-install">
+        <echo msg="Installing plug-ins…"/>
+        <exec command="composer require ${phile.plugins}" logoutput="true" />
+    </target>
+
+    <target name="phile-plugins-uninstall">
+        <echo msg="Uninstalling plug-ins…"/>
+        <exec command="composer remove ${phile.plugins}" logoutput="true" />
+    </target>
+
+
 
 </project>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,4 +17,8 @@
         <directory suffix=".php">plugins/phile</directory>
       </whitelist>
     </filter>
+
+    <logging>
+      <log type="coverage-html" target="docs/coverage" />
+    </logging>
 </phpunit>


### PR DESCRIPTION
This PR should give us a basic idea if a core change accidentally breaks plugins or if plugins need updating after a deliberately breaking core change. Having plugins which can be easily pulled-in via composer is great, having them not work makes them rather useless.

So this PR adds a new phing tasks which installs additional plugins (currently phile/rss-feed only). On travis-ci this task is executed and installs the plugins before tests are run. So if plugins have test-cases – [I added a basic test case to phile/rss-feed](https://github.com/PhileCMS/phileRSSFeed/blob/master/tests/PluginTest.php) – those plugin tests are executed too.

Additional plugins can be updated with test cases and added over time.

Pro: plugins should be become more reliable. Con: it's a commitment to actually keep plugins up to date and those popular "it's slightly breaking but probably not a problem" core changes become  harder.

Something should be done to detect plugin breakage. I'm not saying that this is the best solution/implementation, lets just have something raising a flag somewhere. Better ideas welcome.