### PR TITLE
makes cache service always available

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Phile local configuration.
+ * Local Phile configuration.
  *
- * You can also overwrite Phile-defaults here.
+ * This configuration allows to customize Phile. It overwrites
+ * settings made in defaults.php or plugin-defaults. See those
+ * for additional Phile configuration settings.
  */
 $config = [];
 
@@ -22,8 +24,13 @@ $config['site_title'] = 'PhileCMS';
 $config['theme'] = 'default';
 
 /**
- * demo plugin
+ * Activate the persistent cache for better performance.
  */
-// $config['plugins']['mycompany\\demoPlugin'] = ['active' => true];
+//$config['plugins']['phile\\phpFastCache'] = ['active' => true, 'storage' => 'files'];
+
+/**
+ * Use the demo-plugin as a starting point to write your own plugins.
+ */
+//$config['plugins']['mycompany\\demoPlugin'] = ['active' => true];
 
 return $config;

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -123,9 +123,16 @@ $config['plugins'] = [
      */
     'phile\\templateTwig' => ['active' => true],
     /**
-     * cache engine
+     * Sets the cache engine.
+     *
+     * For easy development the cache is set to a storage that's non-persistent
+     * and in memory only. In production this should be set to a persistent
+     * storage.
+     *
+     * See http://www.phpfastcache.com/ for available cache engines. The easiest
+     * solution is to use files ('storage' => 'Files').
      */
-    'phile\\phpFastCache' => ['active' => true],
+    'phile\\phpFastCache' => ['active' => true, 'storage' => 'Memstatic'],
     /**
      * persistent data storage
      */

--- a/lib/Phile/Repository/Page.php
+++ b/lib/Phile/Repository/Page.php
@@ -42,9 +42,7 @@ class Page
             $settings = Container::getInstance()->get('Phile_Config')->toArray();
         }
         $this->settings = $settings;
-        if (ServiceLocator::hasService('Phile_Cache')) {
-            $this->cache = ServiceLocator::getService('Phile_Cache');
-        }
+        $this->cache = ServiceLocator::getService('Phile_Cache');
     }
 
     /**
@@ -200,15 +198,11 @@ class Page
             return $this->storage[$key];
         }
 
-        if ($this->cache !== null) {
-            if ($this->cache->has($key)) {
-                $page = $this->cache->get($key);
-            } else {
-                $page = new \Phile\Model\Page($filePath, $folder);
-                $this->cache->set($key, $page);
-            }
+        if ($this->cache->has($key)) {
+            $page = $this->cache->get($key);
         } else {
             $page = new \Phile\Model\Page($filePath, $folder);
+            $this->cache->set($key, $page);
         }
         $page->setRepository($this);
         $this->storage[$key] = $page;

--- a/lib/Phile/Test/TestCase.php
+++ b/lib/Phile/Test/TestCase.php
@@ -70,6 +70,10 @@ abstract class TestCase extends PHPUnitTestCase
             $eventBus->trigger('phile.core.middleware.add', ['middleware' => $middleware]);
             $middleware->add($core, 0);
         });
+        
+        //# additional test setup
+        // clears out warnings of inefficient/multiple calls
+        \phpFastCache\CacheManager::clearInstances();
 
         return $core;
     }

--- a/plugins/phile/phpFastCache/Classes/Plugin.php
+++ b/plugins/phile/phpFastCache/Classes/Plugin.php
@@ -26,11 +26,6 @@ class Plugin extends AbstractPlugin
      */
     public function onPluginsLoaded()
     {
-        if (PHILE_CLI_MODE) {
-            // phpFastCache not working in CLI mode...
-            return;
-        }
-
         $storage = $this->settings['storage'];
         $config = $this->settings;
         unset($config['active'], $config['storage']);

--- a/tests/Phile/ServiceLocatorTest.php
+++ b/tests/Phile/ServiceLocatorTest.php
@@ -26,7 +26,7 @@ class ServiceLocatorTest extends TestCase
     public function testServicePhileCacheExists()
     {
         $this->assertEquals(
-            false,
+            true,
             \Phile\Core\ServiceLocator::hasService(
                 'Phile_Cache'
             )


### PR DESCRIPTION
Previous discussion see #327 

Makes the cache service always available. Out of the box Phile provides a memory-only non-persistent cache now. For production the cache should be changed to a persistent cache as indicated in the config.php.