### PR TITLE
Improve error handling

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,14 +21,11 @@ try {
     }
 
     $server->emit($response);
-} catch (\Exception $e) {
+} catch (\Throwable $e) {
     if (\Phile\Core\ServiceLocator::hasService('Phile_ErrorHandler')) {
         ob_end_clean();
-
         /** @var \Phile\ServiceLocator\ErrorHandlerInterface $errorHandler */
-        $errorHandler = \Phile\Core\ServiceLocator::getService(
-            'Phile_ErrorHandler'
-        );
+        $errorHandler = \Phile\Core\ServiceLocator::getService('Phile_ErrorHandler');
         $errorHandler->handleException($e);
     } else {
         throw $e;

--- a/lib/Phile/Core/Bootstrap.php
+++ b/lib/Phile/Core/Bootstrap.php
@@ -82,11 +82,13 @@ class Bootstrap
     public static function setupErrorHandler(Config $config)
     {
         $cliMode = $config->get('phile_cli_mode');
-        if (!$cliMode && ServiceLocator::hasService('Phile_ErrorHandler')) {
-            $errorHandler = ServiceLocator::getService('Phile_ErrorHandler');
-            set_error_handler([$errorHandler, 'handleError']);
-            register_shutdown_function([$errorHandler, 'handleShutdown']);
-            ini_set('display_errors', $config->get('display_errors'));
+        if ($cliMode || !ServiceLocator::hasService('Phile_ErrorHandler')) {
+            return;
         }
+        $errorHandler = ServiceLocator::getService('Phile_ErrorHandler');
+        set_error_handler([$errorHandler, 'handleError']);
+        set_exception_handler([$errorHandler, 'handleException']);
+        register_shutdown_function([$errorHandler, 'handleShutdown']);
+        ini_set('display_errors', $config->get('display_errors'));
     }
 }

--- a/lib/Phile/ServiceLocator/ErrorHandlerInterface.php
+++ b/lib/Phile/ServiceLocator/ErrorHandlerInterface.php
@@ -16,22 +16,26 @@ interface ErrorHandlerInterface
     /**
      * handle the error
      *
-     * @param int    $errno
+     * @param int $errno
      * @param string $errstr
-     * @param string $errfile
-     * @param int    $errline
-     * @param array  $errcontext
+     * @param string|null $errfile
+     * @param int|null $errline
      *
-     * @return boolean
+     * @return bool
      */
-    public function handleError($errno, $errstr, $errfile, $errline, array $errcontext);
+    public function handleError(int $errno, string $errstr, ?string $errfile, ?string $errline);
 
     /**
      * handle all exceptions
      *
-     * @param \Exception $exception
+     * @param \Throwable $exception
      *
      * @return mixed
      */
-    public function handleException(\Exception $exception);
+    public function handleException(\Throwable $exception);
+
+    /**
+     * handle shutdown
+     */
+    public function handleShutdown();
 }

--- a/plugins/phile/errorHandler/Classes/Development.php
+++ b/plugins/phile/errorHandler/Classes/Development.php
@@ -41,11 +41,10 @@ class Development implements ErrorHandlerInterface
      * @param string $errstr
      * @param string $errfile
      * @param int    $errline
-     * @param array  $errcontext
      *
      * @return boolean
      */
-    public function handleError($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function handleError(int $errno, string $errstr, ?string $errfile, ?string $errline)
     {
         $backtrace = debug_backtrace();
         $backtrace = array_slice($backtrace, 2);
@@ -82,7 +81,7 @@ class Development implements ErrorHandlerInterface
      *
      * @return mixed
      */
-    public function handleException(\Exception $exception)
+    public function handleException(\Throwable $exception)
     {
         $this->displayDeveloperOutput(
             $exception->getCode(),
@@ -110,7 +109,7 @@ class Development implements ErrorHandlerInterface
         $file,
         $line,
         array $backtrace = null,
-        \Exception $exception = null
+        \Throwable $exception = null
     ) {
         header('HTTP/1.1 500 Internal Server Error');
         $fragment = $this->receiveCodeFragment(

--- a/plugins/phile/errorHandler/Classes/ErrorLog.php
+++ b/plugins/phile/errorHandler/Classes/ErrorLog.php
@@ -19,13 +19,12 @@ class ErrorLog implements ErrorHandlerInterface
      * @param string $errstr
      * @param string $errfile
      * @param int    $errline
-     * @param array  $errcontext
      *
      * @return boolean
      */
-    public function handleError($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function handleError(int $errno, string $errstr, ?string $errfile, ?string $errline)
     {
-        error_log("[{$errno}] {$errstr} in {$errfile} on line {$errline}");
+        $this->log($errno, $errstr, $errfile, $errline);
     }
 
     /**
@@ -35,12 +34,26 @@ class ErrorLog implements ErrorHandlerInterface
      *
      * @return mixed
      */
-    public function handleException(\Exception $exception)
+    public function handleException(\Throwable $exception)
     {
-        $code = $exception->getCode();
+        $code = (int)$exception->getCode();
         $message = $exception->getMessage();
         $file = $exception->getFile();
         $line = $exception->getLine();
+        $this->log($code, $message, $file, $line);
+    }
+
+    public function handleShutdown()
+    {
+        $error = error_get_last();
+        if ($error === null) {
+            return;
+        }
+        $this->log($error['type'], $error['message'], $error['file'], $error['line']);
+    }
+
+    protected function log(int $code, string $message, ?string $file, ?string $line): void
+    {
         error_log("[{$code}] {$message} in {$file} on line {$line}");
     }
 }


### PR DESCRIPTION
- Explicitly sets exception handler with `set_exception_handler()`
- Catches `\Throwable` instead of `\Exception`
- Adds `ErrorHandlerInterface::handleShutdown`, which was already required by the core