### PR TITLE
improves PSR-15 related process handling

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -95,5 +95,5 @@ $app->addMiddleware(function (MiddlewareQueue $middleware, Event $eventBus, Conf
     $eventBus->trigger('phile.core.middleware.add', ['middleware' => $middleware]);
 
     // Add Phile itself as middleware (take request and render output)
-    $middleware->add($app, 0);
+    $middleware->add($app);
 });

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -84,6 +84,11 @@ $config['content_ext'] = '.md';
 $config['not_found_page'] = '404';
 
 /**
+ * Catch a 404 in Phile and don't pass it on in the middleware-queue
+ */
+$config['handle_not_found'] = true;
+
+/**
  * include core plugins
  */
 $config['plugins'] = [

--- a/content/index.md
+++ b/content/index.md
@@ -194,6 +194,14 @@ this event is triggered after the template is rendered
 | `templateEngine`        | \Phile\Template\TemplateInterface  | the template engine                                                  |
 | `output`                | string                             | the parsed and ready output                                          |
 
+#### after\_response\_created
+
+This event is triggered after the response is created with the rendered template.
+
+| param                   | type                               | description                                                          |
+| ----------------------- |:-----------------------------------|:---------------------------------------------------------------------|
+| `response`              | Psr\Http\Message\ResponseInterface | Response with output                       | 
+
 #### before\_read\_file\_meta
 
 this event is triggered before the meta data is read and parsed

--- a/lib/Phile/Http/MiddlewareQueue.php
+++ b/lib/Phile/Http/MiddlewareQueue.php
@@ -18,6 +18,11 @@ use Traversable;
  */
 class MiddlewareQueue implements IteratorAggregate
 {
+    public const DEFAULT_PRIORITY = 100;
+    
+    /** @var int counter for FIFO order for items with same priority */
+    protected $serial = PHP_INT_MAX;
+
     /** @var SplPriorityQueue middleware */
     protected $queue;
 
@@ -33,9 +38,9 @@ class MiddlewareQueue implements IteratorAggregate
      * @param int $priority
      * @return \self
      */
-    public function add(MiddlewareInterface $middleware, int $priority = 100): self
+    public function add(MiddlewareInterface $middleware, int $priority = self::DEFAULT_PRIORITY): self
     {
-        $this->queue->insert($middleware, $priority);
+        $this->queue->insert($middleware, [$priority, $this->serial--]);
         return $this;
     }
 

--- a/lib/Phile/Test/TestCase.php
+++ b/lib/Phile/Test/TestCase.php
@@ -68,7 +68,7 @@ abstract class TestCase extends PHPUnitTestCase
         //# setup middleware
         $core->addMiddleware(function ($middleware, $eventBus, $config) use ($core) {
             $eventBus->trigger('phile.core.middleware.add', ['middleware' => $middleware]);
-            $middleware->add($core, 0);
+            $middleware->add($core);
         });
 
         return $core;


### PR DESCRIPTION
- adds an "after_response_created" event
- adds a config parameter "catch_not_found" deciding if Phile should catch a not found request or pass it on
- allows to add middleware "below" Phile
- preserves insert order for middleware items with same priority