### PR TITLE
Moves Phile core autoloading to composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,14 @@ install:
 
 script:
 - |
-  echo;
-  echo "Running unit tests";
+  echo; echo "Running unit tests";
   lib/vendor/bin/phpunit;
 - |
-  echo; echo "Running php lint"; /bin/bash -c "
-    if ! find lib -name \*.php -not -path 'lib/vendor/*' -exec php -l {} \; > /tmp/errors 2>&1; then
+  echo; echo "Running code formatting tests";
+  if [ "$PHPCS" = "1" ]; then 
+    if ! find lib plugins/phile -name \*.php -not -path 'lib/vendor/*' -exec php -l "{}" \; > /tmp/errors 2>&1; then
       grep -v \"No syntax errors detected in\" /tmp/errors;
       exit 99;
     fi
-  "
-- sh -c "if [ '$PHPCS' = '1' ]; then lib/vendor/bin/phpcs --standard=PSR2 -p --extensions=php --ignore=lib/vendor/ lib/ plugins/phile/ .; fi"
+    lib/vendor/bin/phpcs --standard=PSR2 -p --extensions=php --ignore=lib/vendor/ lib/ plugins/phile/ .;
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,7 @@ notifications:
 # Scripts
 install:
   - composer selfupdate --quiet
-  - |
-    if [ "$PHPCS" = "1" ] || [ "$PLUGINS" = "1" ]; then
-        composer install --prefer-dist --no-interaction
-    else
-        composer install --no-dev --no-interaction
-    fi
+  - composer install --prefer-dist --no-interaction
   - |
     if [ "$PLUGINS" = "1" ]; then
         lib/vendor/bin/phing phile-plugins-install 
@@ -44,7 +39,7 @@ script:
 - |
   echo;
   echo "Running unit tests";
-  phpunit;
+  lib/vendor/bin/phpunit;
 - |
   echo; echo "Running php lint"; /bin/bash -c "
     if ! find lib -name \*.php -not -path 'lib/vendor/*' -exec php -l {} \; > /tmp/errors 2>&1; then

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,11 @@
     "config": {
         "vendor-dir": "lib/vendor"
     },
+    "autoload": {
+        "psr-4": {
+            "Phile\\": "lib/Phile"
+        }
+    },
     "require": {
         "php": ">=7.1.0",
         "twig/twig": "^1.0 || ^2.0",

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -27,19 +27,6 @@ define('STORAGE_DIR', LIB_DIR . 'datastorage' . DS);
 // phpcs:enable
 
 /**
- * initialize autoloaders
- */
-// load classes from Phile-core
-spl_autoload_register(function ($className) {
-    $fileName = LIB_DIR . str_replace("\\", DS, $className) . '.php';
-    if (file_exists($fileName)) {
-        require_once $fileName;
-    }
-});
-// load composer installed classes
-require(LIB_DIR . 'vendor' . DS . 'autoload.php');
-
-/**
  * Setup global application-object
  */
 require 'container.php';

--- a/index.php
+++ b/index.php
@@ -8,7 +8,8 @@
 
 ob_start();
 
-require_once 'config/bootstrap.php';
+require 'lib/vendor/autoload.php';
+require 'config/bootstrap.php';
 
 $app = Phile\Core\Container::getInstance()->get('Phile_App');
 $server = new Phile\Http\Server($app);


### PR DESCRIPTION
Instead of implementing and registering a custom autoloader handler in PHP the autoloading is handled in composer as PSR-4.