### PR TITLE
fixes Pages without meta block are rendered empty #351

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@
 - Adds support for PHP 8 and removes support for PHP 7.
 - Updated internal cache engine Phpfastcache from 6 to 9.
 
+### Fixed
+-  Pages without meta block are rendered empty #351
+
 ## Release 1.11.1
 
 Please see the [release notes](https://github.com/PhileCMS/Phile/releases/tag/1.11.1) or the [complete change-log](https://github.com/PhileCMS/Phile/compare/1.11.0...1.11.1) for more information

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
 ### Changes 
 - Adds support for PHP 8 and removes support for PHP 7.
 - Updated internal cache engine Phpfastcache from 6 to 9.
+- `Phile\ServiceLocacator\MetaInterface` changed:
+  - Renames `MetaInterface::parse` to `MetaInterface::extractMeta`
+  - Introduces `MetaInterface::extractContent`
 
 ### Fixed
 -  Pages without meta block are rendered empty #351

--- a/lib/Phile/Model/Meta.php
+++ b/lib/Phile/Model/Meta.php
@@ -89,7 +89,7 @@ class Meta extends AbstractModel
          * @var \Phile\ServiceLocator\MetaInterface $metaParser
          */
         $metaParser = ServiceLocator::getService('Phile_Parser_Meta');
-        $data       = $metaParser->parse($rawData);
+        $data       = $metaParser->extractMeta($rawData);
 
         foreach ($data as $key => $value) {
             $this->set($key, $value);

--- a/lib/Phile/Model/Page.php
+++ b/lib/Phile/Model/Page.php
@@ -8,6 +8,7 @@ use Phile\Core\Container;
 use Phile\Core\Router;
 use Phile\Core\ServiceLocator;
 use Phile\Repository\Page as Repository;
+use Phile\ServiceLocator\MetaInterface;
 
 /**
  * the Model class for a page
@@ -173,25 +174,15 @@ class Page
     /**
      * parse the raw content
      */
-    protected function parseRawData()
+    protected function parseRawData(): void
     {
         $this->meta = new Meta($this->rawData);
 
         $content = '';
         if ($this->rawData !== null) {
-            $rawData = trim($this->rawData);
-            $fences = [
-                'c' => ['open' => '/*', 'close' => '*/'],
-                'html' => ['open' => '<!--', 'close' => '-->'],
-                'yaml' => ['open' => '---', 'close' => '---']
-            ];
-            foreach ($fences as $fence) {
-                if (strncmp($fence['open'], $rawData, strlen($fence['open'])) === 0) {
-                    $sub = substr($rawData, strlen($fence['open']));
-                    list(, $content) = explode($fence['close'], $sub, 2);
-                    break;
-                }
-            }
+            /** @var MetaInterface */
+            $metaParser = ServiceLocator::getService('Phile_Parser_Meta');
+            $content = $metaParser->extractContent($this->rawData);
         }
 
         $this->content = $content;

--- a/lib/Phile/ServiceLocator/MetaInterface.php
+++ b/lib/Phile/ServiceLocator/MetaInterface.php
@@ -20,7 +20,7 @@ interface MetaInterface
      *
      * @return array with key/value store
      */
-    public function parse($rawData);
+    public function extractMeta($rawData);
 
     /**
      * Parses text and extracts the content-part (meta-data is removed)

--- a/lib/Phile/ServiceLocator/MetaInterface.php
+++ b/lib/Phile/ServiceLocator/MetaInterface.php
@@ -21,4 +21,12 @@ interface MetaInterface
      * @return array with key/value store
      */
     public function parse($rawData);
+
+    /**
+     * Parses text and extracts the content-part (meta-data is removed)
+     *
+     * @param string $rawData Text to inspect
+     * @return string Text without meta-data
+     */
+    public function extractContent(?string $rawData): string;
 }

--- a/plugins/phile/parserMeta/Classes/Parser/Meta.php
+++ b/plugins/phile/parserMeta/Classes/Parser/Meta.php
@@ -39,7 +39,7 @@ class Meta implements MetaInterface
      *
      * {@inheritdoc}
      */
-    public function parse($rawData)
+    public function extractMeta($rawData)
     {
         list($meta) = $this->splitRawIntoMetaAndContent($rawData);
         

--- a/plugins/phile/parserMeta/Classes/Parser/Meta.php
+++ b/plugins/phile/parserMeta/Classes/Parser/Meta.php
@@ -76,9 +76,6 @@ class Meta implements MetaInterface
      */
     protected function splitRawIntoMetaAndContent(string $rawData): array
     {
-        $rawData = trim($rawData);
-        $fences = $this->config['fences'];
-
         $meta = null;
         $content = $rawData;
 

--- a/plugins/phile/parserMeta/Classes/Parser/Meta.php
+++ b/plugins/phile/parserMeta/Classes/Parser/Meta.php
@@ -41,7 +41,7 @@ class Meta implements MetaInterface
      */
     public function parse($rawData)
     {
-        list($meta) = $this->findFenceStop($rawData);
+        list($meta) = $this->splitRawIntoMetaAndContent($rawData);
         
         if ($meta === null) {
             return [];
@@ -63,7 +63,7 @@ class Meta implements MetaInterface
      */
     public function extractContent(?string $rawData): string
     {
-        list(, $content) = $this->findFenceStop($rawData);
+        list(, $content) = $this->splitRawIntoMetaAndContent($rawData);
         
         return $content;
     }
@@ -74,7 +74,7 @@ class Meta implements MetaInterface
      * @param string $rawData Text to inspect
      * @return array array with [meta-data, content]
      */
-    protected function findFenceStop(string $rawData): array
+    protected function splitRawIntoMetaAndContent(string $rawData): array
     {
         $rawData = trim($rawData);
         $fences = $this->config['fences'];

--- a/plugins/phile/parserMeta/tests/MetaTest.php
+++ b/plugins/phile/parserMeta/tests/MetaTest.php
@@ -28,4 +28,18 @@ EOF;
         $this->assertSame('foo', $meta['title']);
         $this->assertSame(['bar', 'baz'], $meta['tags']);
     }
+
+    public function testDataWithoutMetaDataBlock()
+    {
+        $raw = "# Hello World\n## Hello you too";
+        $parser = new Meta([
+            'fences' => ['yaml' => ['open' => '---', 'close' => '---']],
+        ]);
+
+        $content = $parser->extractContent($raw);
+        $this->assertSame($raw, $content);
+
+        $meta = $parser->parse($raw);
+        $this->assertSame([], $meta);
+    }
 }

--- a/plugins/phile/parserMeta/tests/MetaTest.php
+++ b/plugins/phile/parserMeta/tests/MetaTest.php
@@ -24,7 +24,7 @@ EOF;
             'fences' => ['yaml' => ['open' => '---', 'close' => '---']],
             'format' => 'YAML'
         ]);
-        $meta = $parser->parse($raw);
+        $meta = $parser->extractMeta($raw);
         $this->assertSame('foo', $meta['title']);
         $this->assertSame(['bar', 'baz'], $meta['tags']);
     }
@@ -39,7 +39,7 @@ EOF;
         $content = $parser->extractContent($raw);
         $this->assertSame($raw, $content);
 
-        $meta = $parser->parse($raw);
+        $meta = $parser->extractMeta($raw);
         $this->assertSame([], $meta);
     }
 }


### PR DESCRIPTION
Fixes: #351 

The raw-content has to be split into meta and content.

This was done in two places before (Page and Parser) essentially
duplicating the same functionality. Now this responsibility is delegated to the
Parser, it is the party with the knowledge on how to detect and extract the
meta from the content.

The evaluation of meta and content is still done twice as before, so there's
still room for performance improvement. But at least the implementations are
merged into one code place.
