### PR TITLE
[BUGFIX] Check if property exists in MarkdownExtra class

### DIFF
--- a/plugins/phile/parserMarkdown/Classes/Parser/Markdown.php
+++ b/plugins/phile/parserMarkdown/Classes/Parser/Markdown.php
@@ -43,7 +43,9 @@ class Markdown implements ParserInterface
     {
         $parser = new MarkdownExtra;
         foreach ($this->config as $key => $value) {
-            $parser->{$key} = $value;
+            if (property_exists($parser, $key)) {
+                $parser->{$key} = $value;
+            }
         }
 
         return $parser->transform($data);


### PR DESCRIPTION
Addresses issue #354, fixing the dynamic property ErrorException in PHP 8.2

Changes proposed in this pull request:
Check for property validity before attempting to set custom configuration variables in the Markdown plugin. It's very possible this is not the ideal or correct method for solving the issue, and is offered as a quick fix for anyone running into the same issues I have when running PHP 8.2, until an official approach or correction is recommended.

@PhileCMS/Phile @Schlaefer please review this pull request